### PR TITLE
feat: introduce GameStatus to replace null-based game state (#19)

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/websocket/broker/GameState.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/websocket/broker/GameState.kt
@@ -1,7 +1,19 @@
 package at.aau.hexabrawl.websocketserver.websocket.broker
 
-class GameState(
+/*class GameState(
     var players: MutableList<String> = mutableListOf(),
     var currentTurn: String? = null,
     var units: MutableList<GameUnit> = mutableListOf()
+)*/
+enum class GameStatus {
+    WAITING_FOR_PLAYERS,
+    IN_PROGRESS,
+    FINISHED
+}
+
+data class GameState(
+    val players: MutableList<String> = mutableListOf(),
+    val units: MutableList<GameUnit> = mutableListOf(),
+    var currentTurn: String? = null,
+    var status: GameStatus = GameStatus.WAITING_FOR_PLAYERS
 )

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/websocket/broker/GameState.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/websocket/broker/GameState.kt
@@ -1,10 +1,5 @@
 package at.aau.hexabrawl.websocketserver.websocket.broker
 
-/*class GameState(
-    var players: MutableList<String> = mutableListOf(),
-    var currentTurn: String? = null,
-    var units: MutableList<GameUnit> = mutableListOf()
-)*/
 enum class GameStatus {
     WAITING_FOR_PLAYERS,
     IN_PROGRESS,

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/websocket/broker/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/websocket/broker/WebSocketBrokerController.kt
@@ -15,9 +15,9 @@ class WebSocketBrokerController {
         const val MAX_PLAYERS = 2
     }
 
-    // ************
-    // JOIN (REST)
-    // ************
+    // *******************************************
+    // JOIN (REST) only for Testing with postman
+    // *******************************************
     @PostMapping("/joinTest")
     @ResponseBody
     fun joinTest(@RequestBody name: String): GameState {
@@ -50,7 +50,7 @@ class WebSocketBrokerController {
             gameState.units.add(GameUnit(p2, 5, 5))
 
             gameState.currentTurn = p1
-
+            gameState.status = GameStatus.IN_PROGRESS
             println("GAME STARTED")
         }
 
@@ -105,7 +105,8 @@ class WebSocketBrokerController {
         println("Move from: ${move.player}")
 
         // Reject if game not started
-        if (gameState.currentTurn == null) {
+        //if (gameState.currentTurn == null) {
+        if (gameState.status == GameStatus.WAITING_FOR_PLAYERS) {
             println("REJECTED: Game not started")
             return gameState
         }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/GameStateTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/GameStateTest.kt
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+import at.aau.hexabrawl.websocketserver.websocket.broker.GameStatus
+
 class GameStateTest {
 
     private lateinit var gameState: GameState
@@ -21,6 +23,7 @@ class GameStateTest {
         assertEquals(0, gameState.players.size)
         assertEquals(0, gameState.units.size)
         assertNull(gameState.currentTurn)
+        assertEquals(GameStatus.WAITING_FOR_PLAYERS, gameState.status)
     }
 
     @Test
@@ -91,4 +94,11 @@ class GameStateTest {
         assertEquals(0, move.toX)
         assertEquals(0, move.toY)
     }
+
+    @Test
+    fun `game state starts with status WAITING_FOR_PLAYERS`() {
+        assertEquals(GameStatus.WAITING_FOR_PLAYERS, gameState.status)
+    }
+
+
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/WebSocketBrokerControllerTest.kt
@@ -1,6 +1,7 @@
 package at.aau.hexabrawl.websocketserver
 
 import at.aau.hexabrawl.websocketserver.websocket.broker.GameState
+import at.aau.hexabrawl.websocketserver.websocket.broker.GameStatus
 import at.aau.hexabrawl.websocketserver.websocket.broker.GameUnit
 import at.aau.hexabrawl.websocketserver.websocket.broker.Move
 import at.aau.hexabrawl.websocketserver.websocket.broker.WebSocketBrokerController
@@ -43,6 +44,7 @@ class WebSocketBrokerControllerTest {
         Assertions.assertEquals(2, state.players.size)
         Assertions.assertNotNull(state.currentTurn)
         Assertions.assertEquals(2, state.units.size)
+        Assertions.assertEquals(GameStatus.IN_PROGRESS, state.status)
     }
 
     @Test
@@ -167,5 +169,17 @@ class WebSocketBrokerControllerTest {
         val result = controller.handleMove(Move("Alice", "MOVE", 0, 0, 1, 1))
 
         assertTrue(result.units.isEmpty())
+    }
+
+    @Test
+    fun `game stays waiting when only one player joins`() {
+        val controller = WebSocketBrokerController()
+
+        val state = controller.join("Alice")
+
+        assertEquals(1, state.players.size)
+        assertEquals(GameStatus.WAITING_FOR_PLAYERS, state.status)
+        assertNull(state.currentTurn)
+        assertTrue(state.units.isEmpty())
     }
 }


### PR DESCRIPTION
### Summary

This PR introduces an explicit `GameStatus` enum in `GameState` to replace null-based logic.

### Changes

* Added `GameStatus` enum (`WAITING_FOR_PLAYERS`, `IN_PROGRESS`, `FINISHED`)
* Extended `GameState` with `status` field
* Updated join logic to set status correctly
* Updated move validation to use `GameStatus`
* Added/updated tests for game start behavior

### Motivation

Previously, `currentTurn = null` was used to indicate that the game had not started.
This was ambiguous and required implicit interpretation on the client side.

### Result

* Clearer state handling
* No null-based logic
* Improved maintainability and client communication

Fixes #19
