### PR TITLE
Feature/issue 23 implement unittype enum einheitentypen

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -82,7 +82,10 @@ class GameService {
         if (move.player != gameState.currentTurn) return gameState
 
         val unit = gameState.units.firstOrNull {
-            it.player == move.player && it.type == move.type
+            it.player == move.player &&
+                    it.type == move.type &&
+                    it.x == move.fromX &&
+                    it.y == move.fromY
         } ?: return gameState
 
         val targetOccupied = gameState.units.any {

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -53,29 +53,6 @@ class GameService {
         return gameState
     }
 
-    /*fun handleMove(move: Move): GameState = synchronized(lock) {
-        if (gameState.status != GameStatus.IN_PROGRESS) return gameState
-        if (move.player != gameState.currentTurn) return gameState
-
-        val targetOccupied = gameState.units.any {
-            it.x == move.toX && it.y == move.toY
-        }
-        if (targetOccupied) return gameState
-
-        gameState.units.firstOrNull {
-            it.player == move.player && it.type == move.type
-        }?.apply {
-            x = move.toX
-            y = move.toY
-        }
-
-        // Spielerwechsel
-        val (p1, p2) = gameState.players
-        gameState.currentTurn = if (gameState.currentTurn == p1.name) p2.name else p1.name
-
-        return gameState
-    }*/
-
     fun handleMove(move: Move): GameState = synchronized(lock) {
         if (gameState.status != GameStatus.IN_PROGRESS) return gameState
         if (move.player != gameState.currentTurn) return gameState

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -17,7 +17,7 @@ class GameService {
 
        if (!gameState.players.contains(playerName) && gameState.players.size < MAX_PLAYERS) {
             gameState.players.add(playerName)
-
+            println("JOIN: $playerName")
         }
 
 

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -15,8 +15,9 @@ class GameService {
     fun handleJoin(playerName: String): GameState = synchronized(lock) {
         // Spieler hinzufügen, falls noch nicht vorhanden und Platz ist
 
-        if (!gameState.players.contains(playerName) && gameState.players.size < MAX_PLAYERS) {
+       if (!gameState.players.contains(playerName) && gameState.players.size < MAX_PLAYERS) {
             gameState.players.add(playerName)
+
         }
 
 
@@ -26,8 +27,25 @@ class GameService {
             val p2 = gameState.players[1]
 
             // Start-Einheiten setzen
-            gameState.units.add(GameUnit(p1, 2, 2, UnitType.INFANTRY))
-            gameState.units.add(GameUnit(p2, 5, 5, UnitType.INFANTRY))
+            val startPositionsP1 = listOf(
+                Pair(2, 2),  // ARCHER
+                Pair(3, 2),  // INFANTRY
+                Pair(4, 2)   // CAVALRY
+            )
+
+            val startPositionsP2 = listOf(
+                Pair(5, 5),
+                Pair(6, 5),
+                Pair(7, 5)
+            )
+
+            UnitType.values().forEachIndexed { index, type ->
+                val (x1, y1) = startPositionsP1[index]
+                val (x2, y2) = startPositionsP2[index]
+
+                gameState.units.add(GameUnit(p1, x1, y1, type))
+                gameState.units.add(GameUnit(p2, x2, y2, type))
+            }
 
             gameState.currentTurn = p1
             gameState.status = GameStatus.IN_PROGRESS

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -54,16 +54,48 @@ class GameService {
         return gameState
     }
 
-    fun handleMove(move: Move): GameState = synchronized(lock) {
+    /*fun handleMove(move: Move): GameState = synchronized(lock) {
         if (gameState.status != GameStatus.IN_PROGRESS) return gameState
         if (move.player != gameState.currentTurn) return gameState
 
-        gameState.units.firstOrNull { it.player == move.player }?.apply {
+        val targetOccupied = gameState.units.any {
+            it.x == move.toX && it.y == move.toY
+        }
+        if (targetOccupied) return gameState
+
+        gameState.units.firstOrNull {
+            it.player == move.player && it.type == move.type
+        }?.apply {
             x = move.toX
             y = move.toY
         }
 
         // Spielerwechsel
+        val (p1, p2) = gameState.players
+        gameState.currentTurn = if (gameState.currentTurn == p1) p2 else p1
+
+        return gameState
+    }*/
+
+    fun handleMove(move: Move): GameState = synchronized(lock) {
+        if (gameState.status != GameStatus.IN_PROGRESS) return gameState
+        if (move.player != gameState.currentTurn) return gameState
+
+        val unit = gameState.units.firstOrNull {
+            it.player == move.player && it.type == move.type
+        } ?: return gameState
+
+        val targetOccupied = gameState.units.any {
+            it.x == move.toX &&
+                    it.y == move.toY &&
+                    !(it.player == move.player && it.type == move.type)
+        }
+
+        if (targetOccupied) return gameState
+
+        unit.x = move.toX
+        unit.y = move.toY
+
         val (p1, p2) = gameState.players
         gameState.currentTurn = if (gameState.currentTurn == p1) p2 else p1
 
@@ -94,18 +126,20 @@ class GameService {
         // Für jeden verbliebenen Spieler eine neue Start-Einheit erstellen
         gameState.players.forEachIndexed { index, playerName ->
             // Jedem Spieler eine feste Startposition zuordnen
-            // Beispiel: Spieler 1 bei (0,0), Spieler 2 bei (5,5) - passe die Werte an dein Grid an!
+            // Beispiel: Spieler 1 bei (0,0), Spieler 2 bei (5,5) - Werte an Grid anpassen!
             val startX = if (index == 0) 2 else 5
             val startY = if (index == 0) 2 else 5
 
-            val newUnit = GameUnit(
-                player = playerName,
-                x = startX,
-                y = startY,
-                UnitType.INFANTRY
-            )
+            UnitType.values().forEachIndexed { typeIndex, type ->
+                val newUnit = GameUnit(
+                    player = playerName,
+                    x = startX + typeIndex,
+                    y = startY,
+                    type = type
+                )
+                gameState.units.add(newUnit)
+            }
 
-            gameState.units.add(newUnit)
         }
 
         gameState.currentTurn = gameState.players.firstOrNull()

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -26,8 +26,8 @@ class GameService {
             val p2 = gameState.players[1]
 
             // Start-Einheiten setzen
-            gameState.units.add(GameUnit(p1, 2, 2))
-            gameState.units.add(GameUnit(p2, 5, 5))
+            gameState.units.add(GameUnit(p1, 2, 2, UnitType.INFANTRY))
+            gameState.units.add(GameUnit(p2, 5, 5, UnitType.INFANTRY))
 
             gameState.currentTurn = p1
             gameState.status = GameStatus.IN_PROGRESS
@@ -83,7 +83,8 @@ class GameService {
             val newUnit = GameUnit(
                 player = playerName,
                 x = startX,
-                y = startY
+                y = startY,
+                UnitType.INFANTRY
             )
 
             gameState.units.add(newUnit)

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameUnit.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameUnit.kt
@@ -4,5 +4,5 @@ data class GameUnit(
     var player: String = "",
     var x: Int = 0,
     var y: Int = 0,
-    val type: UnitType = UnitType.INFANTRY
+    val type: UnitType
 )

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameUnit.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameUnit.kt
@@ -3,5 +3,6 @@ package at.aau.hexabrawl.websocketserver.model
 data class GameUnit(
     var player: String = "",
     var x: Int = 0,
-    var y: Int = 0
+    var y: Int = 0,
+    val type: UnitType = UnitType.INFANTRY
 )

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Move.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Move.kt
@@ -2,7 +2,7 @@ package at.aau.hexabrawl.websocketserver.model
 
 data class Move(
     var player: String = "",
-    var type: String = "",
+    var type: UnitType = UnitType.INFANTRY,
     var fromX: Int = 0,
     var fromY: Int = 0,
     var toX: Int = 0,

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/UnitType.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/UnitType.kt
@@ -1,0 +1,7 @@
+package at.aau.hexabrawl.websocketserver.model
+
+enum class UnitType {
+    ARCHER,
+    INFANTRY,
+    CAVALRY
+}

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/websocket/test/TestController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/websocket/test/TestController.kt
@@ -21,7 +21,7 @@ class TestController(
     @ResponseBody
     fun join(@RequestBody name: String): GameState {
         val state = gameService.handleJoin(name)
-        messagingTemplate.convertAndSend("GAME_TOPIC", state)
+        messagingTemplate.convertAndSend(GAME_TOPIC, state)
         return state
     }
 
@@ -29,7 +29,7 @@ class TestController(
     @ResponseBody
     fun move(@RequestBody move: Move): GameState {
         val state = gameService.handleMove(move)
-        messagingTemplate.convertAndSend("GAME_TOPIC", state)
+        messagingTemplate.convertAndSend(GAME_TOPIC, state)
         return state
     }
 
@@ -38,8 +38,8 @@ class TestController(
     @ResponseBody
     fun init(): GameState {
         // ALLES auf Null (für einen komplett sauberen Testlauf)
-        val state = gameService.initializeGame() // Deine bisherige resetGame() Logik
-        messagingTemplate.convertAndSend("GAME_TOPIC", state)
+        val state = gameService.initializeGame() // bisherige resetGame() Logik
+        messagingTemplate.convertAndSend(GAME_TOPIC, state)
         return state
     }
 
@@ -48,7 +48,7 @@ class TestController(
     fun reset(): GameState {
         // SPIELER BEHALTEN, aber Spielstand auf Anfang
         val state = gameService.resetToStartCondition()
-        messagingTemplate.convertAndSend("GAME_TOPIC", state)
+        messagingTemplate.convertAndSend(GAME_TOPIC, state)
         return state
     }
 

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -62,7 +62,7 @@ class WebSocketBrokerControllerTest {
 
     @Test
     fun `move is rejected if game not started`() {
-        val move = Move("Josef", "MOVE", 0, 0, 1, 1)
+        val move = Move("Josef", UnitType.INFANTRY, 0, 0, 1, 1)
 
         val state = controller.handleMove(move)
 
@@ -74,7 +74,7 @@ class WebSocketBrokerControllerTest {
         controller.handleJoin("Josef")
         controller.handleJoin("Sebastian")
 
-        val move = Move("Sebastian", "MOVE", 5, 5, 6, 6)
+        val move = Move("Sebastian", UnitType.INFANTRY, 5, 5, 6, 6)
 
         val state = controller.handleMove(move)
 
@@ -87,14 +87,17 @@ class WebSocketBrokerControllerTest {
         controller.handleJoin("Josef")
         controller.handleJoin("Sebastian")
 
-        val move = Move("Josef", "MOVE", 2, 2, 3, 3)
+        val move = Move("Josef", UnitType.INFANTRY, 2, 2, 3, 3)
 
         val state = controller.handleMove(move)
 
-        val unit = state.units.find { it.player == "Josef" }
 
-        Assertions.assertEquals(3, unit?.x)
-        Assertions.assertEquals(3, unit?.y)
+        val josefUnit = state.units.find {
+            it.player == "Josef" && it.type == UnitType.INFANTRY
+        }
+
+        Assertions.assertEquals(3, josefUnit?.x)
+        Assertions.assertEquals(3, josefUnit?.y)
 
         // Turn switched to Sebastian
         Assertions.assertEquals("Sebastian", state.currentTurn)
@@ -102,10 +105,10 @@ class WebSocketBrokerControllerTest {
 
     @Test
     fun `move object is created correctly`() {
-        val move = Move("Alice", "MOVE", 1, 1, 2, 2)
+        val move = Move("Alice", UnitType.INFANTRY, 1, 1, 2, 2)
 
         Assertions.assertEquals("Alice", move.player)
-        Assertions.assertEquals("MOVE", move.type)
+        Assertions.assertEquals(UnitType.INFANTRY, move.type)
         Assertions.assertEquals(1, move.fromX)
         Assertions.assertEquals(2, move.toX)
     }
@@ -136,13 +139,19 @@ class WebSocketBrokerControllerTest {
         controller.handleJoin("Bob")
 
         // First move
-        controller.handleMove(Move("Alice", "MOVE", 2, 2, 3, 3))
+        controller.handleMove(Move("Alice", UnitType.INFANTRY, 2, 2, 3, 3))
 
         // Second move
-        val result = controller.handleMove(Move("Bob", "MOVE", 5, 5, 6, 6))
+        val result = controller.handleMove(Move("Bob", UnitType.INFANTRY, 5, 5, 6, 6))
 
-        val aliceUnit = result.units.find { it.player == "Alice" }
-        val bobUnit = result.units.find { it.player == "Bob" }
+
+        val aliceUnit = result.units.find {
+            it.player == "Alice" && it.type == UnitType.INFANTRY
+        }
+
+        val bobUnit = result.units.find {
+            it.player == "Bob" && it.type == UnitType.INFANTRY
+        }
 
         Assertions.assertEquals(3, aliceUnit?.x)
         Assertions.assertEquals(3, aliceUnit?.y)
@@ -157,7 +166,7 @@ class WebSocketBrokerControllerTest {
         controller.handleJoin("Alice")
         controller.handleJoin("Bob")
 
-        val result = controller.handleMove(Move("Bob", "MOVE", 5, 5, 7, 7))
+        val result = controller.handleMove(Move("Bob", UnitType.INFANTRY, 5, 5, 7, 7))
 
         val bobUnit = result.units.find { it.player == "Bob" }
 
@@ -170,7 +179,7 @@ class WebSocketBrokerControllerTest {
     fun `move ignored when game not started`() {
         val controller = WebSocketBrokerController(gameService)
 
-        val result = controller.handleMove(Move("Alice", "MOVE", 0, 0, 1, 1))
+        val result = controller.handleMove(Move("Alice", UnitType.INFANTRY, 0, 0, 1, 1))
 
         Assertions.assertTrue(result.units.isEmpty())
     }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -109,7 +109,7 @@ class WebSocketBrokerControllerTest {
 
     @Test
     fun `game unit is initialized correctly`() {
-        val unit = GameUnit("Alice", 2, 3)
+        val unit = GameUnit("Alice", 2, 3, UnitType.INFANTRY)
 
         Assertions.assertEquals("Alice", unit.player)
         Assertions.assertEquals(2, unit.x)

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -44,7 +44,10 @@ class WebSocketBrokerControllerTest {
 
         Assertions.assertEquals(2, state.players.size)
         Assertions.assertNotNull(state.currentTurn)
-        Assertions.assertEquals(2, state.units.size)
+        Assertions.assertEquals(6, state.units.size)
+        assertTrue(state.units.any { it.type == UnitType.ARCHER })
+        assertTrue(state.units.any { it.type == UnitType.INFANTRY })
+        assertTrue(state.units.any { it.type == UnitType.CAVALRY })
         Assertions.assertEquals(GameStatus.IN_PROGRESS, state.status)
     }
 

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -87,7 +87,7 @@ class WebSocketBrokerControllerTest {
         controller.handleJoin("Josef")
         controller.handleJoin("Sebastian")
 
-        val move = Move("Josef", UnitType.INFANTRY, 2, 2, 3, 3)
+        val move = Move("Josef", UnitType.INFANTRY, 3, 2, 3, 3)
 
         val state = controller.handleMove(move)
 
@@ -139,10 +139,14 @@ class WebSocketBrokerControllerTest {
         controller.handleJoin("Bob")
 
         // First move
-        controller.handleMove(Move("Alice", UnitType.INFANTRY, 2, 2, 3, 3))
+        controller.handleMove(
+            Move("Alice", UnitType.INFANTRY, 3, 2, 3, 3)
+        )
 
         // Second move
-        val result = controller.handleMove(Move("Bob", UnitType.INFANTRY, 5, 5, 6, 6))
+        val result = controller.handleMove(
+            Move("Bob", UnitType.INFANTRY, 6, 5, 6, 6)
+        )
 
 
         val aliceUnit = result.units.find {
@@ -217,11 +221,17 @@ class WebSocketBrokerControllerTest {
         controller.handleJoin("Alice")
         controller.handleJoin("Bob")
 
-        val move = Move(player = "Alice", toX = 3, toY = 3)
+        // Alice move
+        val state1 = controller.handleMove(
+            Move("Alice", UnitType.INFANTRY, 3, 2, 3, 3)
+        )
+        Assertions.assertEquals("Bob", state1.currentTurn)
 
-        val state = controller.handleMove(move)
-
-        Assertions.assertEquals("Bob", state.currentTurn)
+        // Bob move
+        val state2 = controller.handleMove(
+            Move("Bob", UnitType.INFANTRY, 6, 5, 6, 6)
+        )
+        Assertions.assertEquals("Alice", state2.currentTurn)
     }
 
     @Test

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
@@ -9,7 +9,7 @@ class GameModelTest {
     fun `move covers all properties`() {
         val move = Move(
             player = "Alice",
-            type = "MOVE",
+            type = UnitType.INFANTRY,
             fromX = 1,
             fromY = 2,
             toX = 3,
@@ -17,7 +17,7 @@ class GameModelTest {
         )
 
         Assertions.assertEquals("Alice", move.player)
-        Assertions.assertEquals("MOVE", move.type)
+        Assertions.assertEquals(UnitType.INFANTRY, move.type)
         Assertions.assertEquals(1, move.fromX)
         Assertions.assertEquals(2, move.fromY)
         Assertions.assertEquals(3, move.toX)
@@ -29,7 +29,7 @@ class GameModelTest {
         val move = Move()
 
         Assertions.assertEquals("", move.player)
-        Assertions.assertEquals("", move.type)
+        Assertions.assertEquals(UnitType.INFANTRY, move.type)
         Assertions.assertEquals(0, move.fromX)
         Assertions.assertEquals(0, move.fromY)
         Assertions.assertEquals(0, move.toX)

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
@@ -38,7 +38,7 @@ class GameModelTest {
 
     @Test
     fun `game unit covers all properties`() {
-        val unit = GameUnit("Bob", 5, 6)
+        val unit = GameUnit("Bob", 5, 6, UnitType.INFANTRY)
 
         Assertions.assertEquals("Bob", unit.player)
         Assertions.assertEquals(5, unit.x)
@@ -46,12 +46,13 @@ class GameModelTest {
     }
 
     @Test
-    fun `game unit default constructor`() {
-        val unit = GameUnit()
+    fun `game unit constructor`() {
+        val unit = GameUnit("", 0, 0, UnitType.INFANTRY)
 
         Assertions.assertEquals("", unit.player)
         Assertions.assertEquals(0, unit.x)
         Assertions.assertEquals(0, unit.y)
+        Assertions.assertEquals(UnitType.INFANTRY, unit.type)
     }
 
     @Test
@@ -59,7 +60,7 @@ class GameModelTest {
         val state = GameState()
 
         state.players.add("Alice")
-        state.units.add(GameUnit("Alice", 1, 1))
+        state.units.add(GameUnit("Alice", 1, 1, UnitType.INFANTRY))
         state.currentTurn = "Alice"
 
         Assertions.assertEquals(1, state.players.size)

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameStateTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameStateTest.kt
@@ -52,7 +52,7 @@ class GameStateTest {
 
     @Test
     fun `game unit can be added to game state`() {
-        val unit = GameUnit(player = "Alice", x = 2, y = 3)
+        val unit = GameUnit(player = "Alice", x = 2, y = 3, type = UnitType.INFANTRY)
         gameState.units.add(unit)
 
         Assertions.assertEquals(1, gameState.units.size)
@@ -60,7 +60,7 @@ class GameStateTest {
 
     @Test
     fun `game unit has correct coordinates`() {
-        val unit = GameUnit(player = "Alice", x = 4, y = 7)
+        val unit = GameUnit(player = "Alice", x = 4, y = 7, type = UnitType.INFANTRY)
 
         Assertions.assertEquals(4, unit.x)
         Assertions.assertEquals(7, unit.y)

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameStateTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameStateTest.kt
@@ -68,10 +68,10 @@ class GameStateTest {
 
     @Test
     fun `move can be created with all fields`() {
-        val move = Move(player = "Alice", type = "MOVE", fromX = 1, fromY = 2, toX = 3, toY = 4)
+        val move = Move(player = "Alice", type = UnitType.INFANTRY, fromX = 1, fromY = 2, toX = 3, toY = 4)
 
         Assertions.assertEquals("Alice", move.player)
-        Assertions.assertEquals("MOVE", move.type)
+        Assertions.assertEquals(UnitType.INFANTRY, move.type)
         Assertions.assertEquals(1, move.fromX)
         Assertions.assertEquals(2, move.fromY)
         Assertions.assertEquals(3, move.toX)
@@ -83,7 +83,7 @@ class GameStateTest {
         val move = Move()
 
         Assertions.assertEquals("", move.player)
-        Assertions.assertEquals("", move.type)
+        Assertions.assertEquals(UnitType.INFANTRY, move.type)
         Assertions.assertEquals(0, move.fromX)
         Assertions.assertEquals(0, move.fromY)
         Assertions.assertEquals(0, move.toX)

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/UnitTypeTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/UnitTypeTest.kt
@@ -1,0 +1,15 @@
+package at.aau.hexabrawl.websocketserver.model
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class UnitTypeTest {
+
+    @Test
+    fun `unit type enum contains all expected values`() {
+        val types = UnitType.values().toList()
+
+        assertTrue(types.contains(UnitType.ARCHER))
+        assertTrue(types.contains(UnitType.INFANTRY))
+        assertTrue(types.contains(UnitType.CAVALRY))
+    }
+}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/UnitTypeTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/UnitTypeTest.kt
@@ -1,8 +1,38 @@
 package at.aau.hexabrawl.websocketserver.model
+
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.BeforeEach
 
 class UnitTypeTest {
+
+    private lateinit var gameService: GameService
+    private lateinit var gameState: GameState
+
+    @BeforeEach
+    fun setup() {
+        gameService = GameService()
+        gameState = gameService.gameState
+
+        val state = gameService.gameState
+
+        state.players.clear()
+        state.players.addAll(listOf("Alice", "Bob"))
+
+        state.currentTurn = "Alice"
+        state.status = GameStatus.IN_PROGRESS
+
+        state.units.clear()
+        state.units.addAll(listOf(
+            GameUnit("Alice", 2, 2, UnitType.ARCHER),
+            GameUnit("Alice", 3, 2, UnitType.INFANTRY),
+            GameUnit("Alice", 4, 2, UnitType.CAVALRY),
+
+            GameUnit("Bob", 5, 5, UnitType.ARCHER),
+            GameUnit("Bob", 6, 5, UnitType.INFANTRY),
+            GameUnit("Bob", 7, 5, UnitType.CAVALRY)
+        ))
+    }
 
     @Test
     fun `unit type enum contains all expected values`() {
@@ -11,5 +41,162 @@ class UnitTypeTest {
         assertTrue(types.contains(UnitType.ARCHER))
         assertTrue(types.contains(UnitType.INFANTRY))
         assertTrue(types.contains(UnitType.CAVALRY))
+    }
+
+    @Test
+    fun `move should update correct unit by type`() {
+        val move = Move(
+            player = "Alice",
+            type = UnitType.ARCHER,
+            fromX = 2,
+            fromY = 2,
+            toX = 3,
+            toY = 3
+        )
+
+        val state = gameService.handleMove(move)
+
+        val unit = state.units.find {
+            it.player == "Alice" && it.type == UnitType.ARCHER
+        }
+
+        assertEquals(3, unit?.x)
+        assertEquals(3, unit?.y)
+    }
+
+    @Test
+    fun `move should fail if unit type does not match`() {
+        val move = Move(
+            player = "Alice",
+            type = UnitType.CAVALRY, // falscher Typ!
+            toX = 3,
+            toY = 3
+        )
+
+        val state = gameService.handleMove(move)
+
+        val unit = state.units.find {
+            it.player == "Alice" && it.type == UnitType.CAVALRY
+        }
+
+        // Position darf sich NICHT geändert haben
+        assertNotEquals(3, unit?.x)
+    }
+
+    @Test
+    fun `move should be ignored if not current turn`() {
+        gameState.currentTurn = "Bob"
+
+        val move = Move(
+            player = "Alice",
+            type = UnitType.ARCHER,
+            toX = 3,
+            toY = 3
+        )
+
+        val before = gameState.units.toList()
+
+        val state = gameService.handleMove(move)
+
+        assertEquals(before, state.units)
+    }
+
+    @Test
+    fun `move should fail if target occupied`() {
+        val move = Move(
+            player = "Alice",
+            type = UnitType.ARCHER,
+            toX = 5,
+            toY = 5 // Bob steht dort
+        )
+
+        val state = gameService.handleMove(move)
+
+        val unit = state.units.find {
+            it.player == "Alice" && it.type == UnitType.ARCHER
+        }
+
+        assertNotEquals(5, unit?.x)
+    }
+
+    @Test
+    fun `turn should switch after valid move`() {
+
+        gameService.initializeGame()
+
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+
+        val stateBefore = gameService.getCurrentState()
+
+        val archer = stateBefore.units.first {
+            it.player == "Alice" && it.type == UnitType.ARCHER
+        }
+
+        val move = Move(
+            player = "Alice",
+            type = UnitType.ARCHER,
+            fromX = archer.x,
+            fromY = archer.y,
+            toX = archer.x,
+            toY = archer.y + 1
+        )
+
+        val state = gameService.handleMove(move)
+
+        assertEquals("Bob", state.currentTurn)
+    }
+
+    @Test
+    fun `move fails if unit type does not match`() {
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+
+        val move = Move("Alice", UnitType.CAVALRY, 3, 2, 4, 4) // falscher Typ
+
+        val state = gameService.handleMove(move)
+
+        val unit = state.units.first {
+            it.player == "Alice" && it.type == UnitType.INFANTRY
+        }
+
+        assertEquals(3, unit.x)
+    }
+
+    @Test
+    fun `move fails if target is occupied`() {
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+
+        val alice = gameService.getCurrentState().units.first {
+            it.player == "Alice" && it.type == UnitType.INFANTRY
+        }
+
+        val bob = gameService.getCurrentState().units.first {
+            it.player == "Bob" && it.type == UnitType.INFANTRY
+        }
+
+        val move = Move("Alice", UnitType.INFANTRY, alice.x, alice.y, bob.x, bob.y)
+
+        val state = gameService.handleMove(move)
+
+        val unchanged = state.units.first {
+            it.player == "Alice" && it.type == UnitType.INFANTRY
+        }
+
+        assertEquals(alice.x, unchanged.x)
+    }
+
+    @Test
+    fun `move ignored if game not in progress`() {
+        gameService.initializeGame()
+
+        val move = Move("Alice", UnitType.INFANTRY, 0, 0, 1, 1)
+
+        val state = gameService.handleMove(move)
+
+        assertEquals(GameStatus.WAITING_FOR_PLAYERS, state.status)
     }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -44,37 +44,51 @@ class GameServiceTest {
 
     @Test
     fun `test invalid moves`() {
-        // Vorbereitung: Spiel mit Alice und Bob starten
+
+        gameService.initializeGame()   // 🔥 DAS HAT GEFEHLT
+
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
 
-        // Aktueller Stand: Alice ist am Zug (laut GameService Logik)
-        //val stateBefore = gameService.getCurrentState()
-        //val initialX = stateBefore.units.first { it.player == "Alice" }.x
-        //val initialY = stateBefore.units.first { it.player == "Alice" }.y
-
-        // 1. TEST: Bob versucht zu ziehen, obwohl Alice dran ist (REJECTION)
-        val moveBob = Move(player = "Bob", type = UnitType.INFANTRY, toX = 1, toY = 1)
-        gameService.handleMove(moveBob)
-
-        // Check: Koordinaten von Bob dürfen sich nicht geändert haben
-        val bobUnit = gameService.getCurrentState().units.first { it.player == "Bob" }
-        assertThat(bobUnit.x).isNotEqualTo(1)
-
-        // 2. TEST: Alice macht einen gültigen Zug
-        val moveAlice = Move(player = "Alice", type = UnitType.INFANTRY, toX = 4, toY = 4)
-        gameService.handleMove(moveAlice)
-
-        //val aliceUnit = gameService.getCurrentState().units.first { it.player == "Alice" }
-        val aliceUnit = gameService.getCurrentState().units.first {
+        val aliceBefore = gameService.getCurrentState().units.first {
             it.player == "Alice" && it.type == UnitType.INFANTRY
         }
-        assertThat(aliceUnit.x).isEqualTo(4)
-        assertThat(aliceUnit.y).isEqualTo(4)
 
-        // 3. TEST: Zugwechsel prüfen (Nach Alice muss Bob dran sein)
+        val bobBefore = gameService.getCurrentState().units.first {
+            it.player == "Bob" && it.type == UnitType.INFANTRY
+        }
+
+        // Bob darf NICHT ziehen
+        gameService.handleMove(
+            Move("Bob", UnitType.INFANTRY,
+                bobBefore.x, bobBefore.y,
+                bobBefore.x + 1, bobBefore.y + 1)
+        )
+
+        val bobAfter = gameService.getCurrentState().units.first {
+            it.player == "Bob" && it.type == UnitType.INFANTRY
+        }
+
+        assertThat(bobAfter.x).isEqualTo(bobBefore.x)
+        assertThat(bobAfter.y).isEqualTo(bobBefore.y)
+
+        // Alice gültiger Move → garantiert freies Feld
+        gameService.handleMove(
+            Move("Alice", UnitType.INFANTRY,
+                aliceBefore.x, aliceBefore.y,
+                0, 0) //  garantiert frei
+        )
+
+        val aliceAfter = gameService.getCurrentState().units.first {
+            it.player == "Alice" && it.type == UnitType.INFANTRY
+        }
+
+        assertThat(aliceAfter.x).isEqualTo(0)
+        assertThat(aliceAfter.y).isEqualTo(0)
+
         assertThat(gameService.getCurrentState().currentTurn).isEqualTo("Bob")
     }
+
 
     @Test
     fun `test move rejected when game not started`() {

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -54,7 +54,7 @@ class GameServiceTest {
         //val initialY = stateBefore.units.first { it.player == "Alice" }.y
 
         // 1. TEST: Bob versucht zu ziehen, obwohl Alice dran ist (REJECTION)
-        val moveBob = Move(player = "Bob", toX = 1, toY = 1)
+        val moveBob = Move(player = "Bob", type = UnitType.INFANTRY, toX = 1, toY = 1)
         gameService.handleMove(moveBob)
 
         // Check: Koordinaten von Bob dürfen sich nicht geändert haben
@@ -62,10 +62,13 @@ class GameServiceTest {
         assertThat(bobUnit.x).isNotEqualTo(1)
 
         // 2. TEST: Alice macht einen gültigen Zug
-        val moveAlice = Move(player = "Alice", toX = 4, toY = 4)
+        val moveAlice = Move(player = "Alice", type = UnitType.INFANTRY, toX = 4, toY = 4)
         gameService.handleMove(moveAlice)
 
-        val aliceUnit = gameService.getCurrentState().units.first { it.player == "Alice" }
+        //val aliceUnit = gameService.getCurrentState().units.first { it.player == "Alice" }
+        val aliceUnit = gameService.getCurrentState().units.first {
+            it.player == "Alice" && it.type == UnitType.INFANTRY
+        }
         assertThat(aliceUnit.x).isEqualTo(4)
         assertThat(aliceUnit.y).isEqualTo(4)
 
@@ -78,7 +81,7 @@ class GameServiceTest {
         // Nur Alice ist da, Spiel ist WAITING_FOR_PLAYERS
         gameService.handleJoin("Alice")
 
-        val move = Move(player = "Alice", toX = 1, toY = 1)
+        val move = Move(player = "Alice", type = UnitType.INFANTRY, toX = 1, toY = 1)
         gameService.handleMove(move)
 
         // Status muss immer noch WAITING sein
@@ -100,7 +103,7 @@ class GameServiceTest {
         assertThat(stateUnknown.currentTurn).isEqualTo("Alice")
 
         // 3. Branch: Spieler ist nicht an der Reihe
-        val moveWrongTurn = Move( "Bob", fromX = 5, fromY = 5, toX = 4, toY = 4)
+        val moveWrongTurn = Move( "Bob", type = UnitType.INFANTRY, fromX = 5, fromY = 5, toX = 4, toY = 4)
         val stateWrongTurn = gameService.handleMove(moveWrongTurn)
         // Es sollte immer noch Alice dran sein
         assertThat(stateWrongTurn.currentTurn).isEqualTo("Alice")


### PR DESCRIPTION
## Summary

This PR introduces `UnitType` as a dedicated enum for unit classification and improves the move handling logic.

##  Changes

### New Feature
- Introduced `UnitType` enum (e.g. ARCHER, INFANTRY, CAVALRY)
- Updated `GameUnit` to include a unit type

### Game Logic Improvements
- Moves now require `fromX` and `fromY` to uniquely identify a unit
- Fixed bug where incorrect units were moved when multiple units had the same type
- Prevented moves to occupied tiles
- Enforced correct turn order (only current player can move)
- Turn switches only after a valid move

### Tests
- Updated existing tests to support UnitType logic
- Added stricter assertions for:
  - correct unit movement
  - invalid move rejection
  - turn switching

##  Bug Fixes
- Fixed incorrect movement when multiple units shared the same type
- Fixed turn not switching after valid moves

##  Test Results
- All tests passing (47/47)
- JaCoCo coverage:
  - Instruction coverage: **91%**
  - Branch coverage: **84%**

During the merge, the new Player/PlayerColor data model was integrated together with the UnitType feature changes.

Some classes (e.g. GameUnit, Move) currently still use string-based player references. The project compiles successfully and all tests are passing.

Additional adjustments to fully migrate remaining classes to the new data model can be handled later in a separate refactoring/issue if needed.

