### PR TITLE
Feature/issue 23 implement unittype enum einheitentypen

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor
+import org.springframework.messaging.handler.annotation.Header
 
 @Controller
 class WebSocketBrokerController(
@@ -28,10 +30,22 @@ class WebSocketBrokerController(
         return message
     }
 
-    @MessageMapping("/join")
+    /*@MessageMapping("/join")
     @SendTo("/topic/game")
     fun join(playerName: String): GameState {
         return gameService.handleJoin(playerName)
+    }*/
+
+    @MessageMapping("/join")
+    @SendTo("/topic/game")
+    fun join(
+        playerName: String,
+        headerAccessor: SimpMessageHeaderAccessor
+    ): GameState {
+
+        val sessionId = headerAccessor.sessionId ?: ""
+
+        return gameService.handleJoin(playerName, sessionId)
     }
 
     @MessageMapping("/init")

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -30,12 +30,6 @@ class WebSocketBrokerController(
         return message
     }
 
-    /*@MessageMapping("/join")
-    @SendTo("/topic/game")
-    fun join(playerName: String): GameState {
-        return gameService.handleJoin(playerName)
-    }*/
-
     @MessageMapping("/join")
     @SendTo("/topic/game")
     fun join(

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -18,6 +18,7 @@ class GameService {
         if (!gameState.players.any{it.name == playerName} && gameState.players.size < MAX_PLAYERS) {
             val color = if (gameState.players.isEmpty()) PlayerColor.RED else PlayerColor.BLUE
             gameState.players.add(Player(playerName, sessionId,color))
+            println("JOIN: $playerName")
         }
 
         // Automatischer Start bei 2 Spielern

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/websocket/test/TestController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/websocket/test/TestController.kt
@@ -18,13 +18,6 @@ class TestController(
             const val GAME_TOPIC = "/topic/game"
     }
 
-    /*@PostMapping("/join")
-    @ResponseBody
-    fun join(@RequestBody name: String): GameState {
-        val state = gameService.handleJoin(name)
-        messagingTemplate.convertAndSend(GAME_TOPIC, state)
-        return state
-    }*/
     @PostMapping("/join")
     @ResponseBody
     fun join(@RequestBody name: String): GameState {

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/websocket/test/TestController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/websocket/test/TestController.kt
@@ -5,6 +5,7 @@ import at.aau.hexabrawl.websocketserver.model.GameState
 import at.aau.hexabrawl.websocketserver.model.Move
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.web.bind.annotation.*
+import java.util.UUID
 
 @RestController
 @RequestMapping("/test")
@@ -17,11 +18,24 @@ class TestController(
             const val GAME_TOPIC = "/topic/game"
     }
 
-    @PostMapping("/join")
+    /*@PostMapping("/join")
     @ResponseBody
     fun join(@RequestBody name: String): GameState {
         val state = gameService.handleJoin(name)
         messagingTemplate.convertAndSend(GAME_TOPIC, state)
+        return state
+    }*/
+    @PostMapping("/join")
+    @ResponseBody
+    fun join(@RequestBody name: String): GameState {
+
+        val fakeSessionId = UUID.randomUUID().toString()
+
+        val state =
+            gameService.handleJoin(name, fakeSessionId)
+
+        messagingTemplate.convertAndSend(GAME_TOPIC, state)
+
         return state
     }
 

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 
 class WebSocketBrokerControllerTest {
 
@@ -191,8 +192,9 @@ class WebSocketBrokerControllerTest {
     @Test
     fun `game stays waiting when only one player joins`() {
         val controller = WebSocketBrokerController(gameService)
+        val headerAccessor = SimpMessageHeaderAccessor.create()
 
-        val state = controller.join("Alice")
+        val state = controller.join("Alice", headerAccessor)
 
         Assertions.assertEquals(1, state.players.size)
         Assertions.assertEquals(GameStatus.WAITING_FOR_PLAYERS, state.status)


### PR DESCRIPTION
## Summary

This PR extends the current player architecture by integrating `sessionId` handling into the join process and adapting the REST test controller to the new player/session model.

## Main Changes

### SessionID integration

The `sessionId` is now determined in the controller join endpoint and passed to:

```kotlin
handleJoin(playerName, sessionId)
```

This allows the server to associate a player with a unique session.

The WebSocket/STOMP controller now retrieves the session ID via:

```kotlin
headerAccessor.sessionId
```

and forwards it to the `GameService`.

---

### Unique player name validation

The server now checks whether a player name already exists before adding a new player:

```kotlin
!gameState.players.any { it.name == playerName }
```

This ensures that currently only one player with a specific name can join the game.

At the moment, the server does not yet send an explicit error message back to the client if a duplicate player name is used.
The join request is simply ignored.

Possible future improvement:

* add explicit server response / error message for duplicate player names

---

### REST test controller compatibility

After introducing the `Player` class with `sessionId`, REST-based test joins no longer behaved like real multiplayer clients because no session ID was available.

To keep the existing Postman/REST testing workflow compatible with the new architecture, the REST `/test/join` endpoint now generates a simulated random session ID:

```kotlin
val fakeSessionId = UUID.randomUUID().toString()
```

This allows REST test players to behave similarly to WebSocket/STOMP players inside the current player/session architecture.

---

## Current Result

The following scenarios were successfully tested:

* Android client movement with `UnitType`
* REST/Postman movement with `UnitType`
* turn switching
* multiplayer simulation with Player + SessionID architecture
* REST test controller compatibility restored

Both Android client and Postman test moves are now working again.
