### PR TITLE
Add Server Health Endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,12 +58,6 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-            <version>4.0.3</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <version>4.0.3</version>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -50,14 +50,6 @@
             <version>4.0.3</version>
         </dependency>
 
-        <!-- Web support for testing (test scope only) -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-            <version>4.0.3</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,12 @@
             <version>4.0.3</version>
         </dependency>
 
+        <!-- Health Endpoint -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,12 @@
             <version>4.0.3</version>
         </dependency>
 
-        <!-- Health Endpoint -->
+        <!-- Web support for testing (test scope only) -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>4.0.3</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>4.0.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <version>4.0.3</version>
             <scope>test</scope>

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthController.kt
@@ -3,12 +3,20 @@ package at.aau.hexabrawl.websocketserver.controller
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 @RestController
 class HealthController {
 
     @GetMapping("/health")
-    fun health(): ResponseEntity<Map<String, String>> {
-        return ResponseEntity.ok(mapOf("status" to "UP"))
+    fun health(): ResponseEntity<Map<String, Any>> {
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        return ResponseEntity.ok(mapOf(
+            "status" to "UP",
+            "service" to "HexaBrawl Game Server",
+            "version" to "1.0.0",
+            "timestamp" to LocalDateTime.now().format(formatter)
+        ))
     }
 }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthController.kt
@@ -1,0 +1,14 @@
+package at.aau.hexabrawl.websocketserver.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class HealthController {
+
+    @GetMapping("/health")
+    fun health(): ResponseEntity<Map<String, String>> {
+        return ResponseEntity.ok(mapOf("status" to "UP"))
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-
+management.endpoints.web.exposure.include=health
+management.endpoint.health.show-details=always

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthControllerTest.kt
@@ -1,0 +1,38 @@
+package at.aau.hexabrawl.websocketserver.controller
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.servlet.assertj.MockMvcTester
+import org.springframework.web.context.WebApplicationContext
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class HealthControllerTest {
+
+    @Autowired
+    private lateinit var context: WebApplicationContext
+
+    private lateinit var mockMvc: MockMvcTester
+
+    @BeforeEach
+    fun setup() {
+        mockMvc = MockMvcTester.from(context)
+    }
+
+    @Test
+    fun `health endpoint returns 200`() {
+        mockMvc.get().uri("/health").exchange()
+            .assertThat()
+            .hasStatusOk()
+    }
+
+    @Test
+    fun `health endpoint returns status UP`() {
+        mockMvc.get().uri("/health").exchange()
+            .assertThat()
+            .hasStatusOk()
+            .bodyJson()
+            .extractingPath("$.status").isEqualTo("UP")
+    }
+}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthControllerTest.kt
@@ -1,38 +1,40 @@
 package at.aau.hexabrawl.websocketserver.controller
 
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.web.servlet.assertj.MockMvcTester
-import org.springframework.web.context.WebApplicationContext
+import org.springframework.http.HttpStatus
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 class HealthControllerTest {
 
-    @Autowired
-    private lateinit var context: WebApplicationContext
-
-    private lateinit var mockMvc: MockMvcTester
-
-    @BeforeEach
-    fun setup() {
-        mockMvc = MockMvcTester.from(context)
-    }
+    private val controller = HealthController()
 
     @Test
     fun `health endpoint returns 200`() {
-        mockMvc.get().uri("/health").exchange()
-            .assertThat()
-            .hasStatusOk()
+        val response = controller.health()
+        assertEquals(HttpStatus.OK, response.statusCode)
     }
 
     @Test
     fun `health endpoint returns status UP`() {
-        mockMvc.get().uri("/health").exchange()
-            .assertThat()
-            .hasStatusOk()
-            .bodyJson()
-            .extractingPath("$.status").isEqualTo("UP")
+        val response = controller.health()
+        assertEquals("UP", response.body?.get("status"))
+    }
+
+    @Test
+    fun `health endpoint returns service name`() {
+        val response = controller.health()
+        assertEquals("HexaBrawl Game Server", response.body?.get("service"))
+    }
+
+    @Test
+    fun `health endpoint returns timestamp`() {
+        val response = controller.health()
+        assertNotNull(response.body?.get("timestamp"))
+    }
+
+    @Test
+    fun `health endpoint returns version`() {
+        val response = controller.health()
+        assertEquals("1.0.0", response.body?.get("version"))
     }
 }


### PR DESCRIPTION
Closes #36

## Changes
- Added HealthController with GET /health endpoint
- Response includes status, service name, version and readable timestamp
- Added HealthControllerTest with 5 unit tests

## Result
GET /health returns:
{
  "status": "UP",
  "service": "HexaBrawl Game Server",
  "version": "1.0.0",
  "timestamp": "2026-05-09 23:34:48"
}

## Security Notes
Security warnings from Mend.io are pre-existing from 
spring-boot-starter-websocket (not introduced by this PR).
