### PR TITLE
Add Disconnect Handler for player disconnection

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandler.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandler.kt
@@ -1,0 +1,24 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import org.springframework.context.event.EventListener
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.messaging.SessionDisconnectEvent
+
+@Component
+class DisconnectHandler(
+    private val gameService: GameService,
+    private val messagingTemplate: SimpMessagingTemplate
+) {
+
+    @EventListener
+    fun handleDisconnect(event: SessionDisconnectEvent) {
+        val sessionId = event.sessionId
+        println("DisconnectHandler: Session $sessionId disconnected")
+
+        val updatedState = gameService.handleDisconnect(sessionId)
+
+        // Broadcast an alle Spieler
+        messagingTemplate.convertAndSend("/topic/game", updatedState)
+    }
+}

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -38,7 +38,7 @@ class GameService {
                 Pair(7, 5)
             )
 
-            UnitType.values().forEachIndexed { index, type ->
+            UnitType.entries.forEachIndexed { index, type ->
                 val (x1, y1) = startPositionsP1[index]
                 val (x2, y2) = startPositionsP2[index]
 
@@ -107,7 +107,7 @@ class GameService {
             val startX = if (index == 0) 2 else 5
             val startY = if (index == 0) 2 else 5
 
-            UnitType.values().forEachIndexed { typeIndex, type ->
+            UnitType.entries.forEachIndexed { typeIndex, type ->
                 val newUnit = GameUnit(
                     player = player.name,
                     x = startX + typeIndex,

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -125,4 +125,24 @@ class GameService {
         return gameState
     }
 
+    fun handleDisconnect(sessionId: String): GameState = synchronized(lock) {
+        val player = gameState.players.find { it.sessionId == sessionId }
+            ?: return gameState
+
+        // Spieler und seine Units entfernen
+        gameState.players.remove(player)
+        gameState.units.removeIf { it.player == player.name }
+
+        // Status anpassen
+        if (gameState.status == GameStatus.IN_PROGRESS) {
+            gameState.status = GameStatus.FINISHED
+            gameState.currentTurn = null
+            println("Service: GAME FINISHED - ${player.name} disconnected")
+        } else {
+            println("Service: PLAYER LEFT - ${player.name} disconnected while waiting")
+        }
+
+        return gameState
+    }
+
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerComponentTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerComponentTest.kt
@@ -1,0 +1,42 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.web.socket.messaging.SessionDisconnectEvent
+
+class DisconnectHandlerComponentTest {
+
+    private val gameService = GameService()
+    private val messagingTemplate = Mockito.mock(SimpMessagingTemplate::class.java)
+    private val handler = DisconnectHandler(gameService, messagingTemplate)
+
+    @Test
+    fun `handleDisconnect broadcasts updated state`() {
+        gameService.handleJoin("Alice", "session-1")
+        gameService.handleJoin("Bob", "session-2")
+
+        val event = Mockito.mock(SessionDisconnectEvent::class.java)
+        Mockito.`when`(event.sessionId).thenReturn("session-1")
+
+        handler.handleDisconnect(event)
+
+        Mockito.verify(messagingTemplate).convertAndSend(
+            ArgumentMatchers.eq("/topic/game"),
+            ArgumentMatchers.any(GameState::class.java)
+        )
+    }
+
+    @Test
+    fun `handleDisconnect removes player from game`() {
+        gameService.handleJoin("Alice", "session-1")
+
+        val event = Mockito.mock(SessionDisconnectEvent::class.java)
+        Mockito.`when`(event.sessionId).thenReturn("session-1")
+
+        handler.handleDisconnect(event)
+
+        assert(gameService.gameState.players.isEmpty())
+    }
+}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerTest.kt
@@ -62,4 +62,16 @@ class DisconnectHandlerTest {
 
         assertNull(gameService.gameState.currentTurn)
     }
+
+    @Test
+    fun `disconnect only removes disconnected player units`() {
+        gameService.handleJoin("Alice", "session-1")
+        gameService.handleJoin("Bob", "session-2")
+
+        gameService.handleDisconnect("session-1")
+
+        val bobUnits = gameService.gameState.units.filter { it.player == "Bob" }
+        assertEquals(3, bobUnits.size)
+    }
+
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerTest.kt
@@ -1,0 +1,65 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class DisconnectHandlerTest {
+
+    private lateinit var gameService: GameService
+
+    @BeforeEach
+    fun setUp() {
+        gameService = GameService()
+    }
+
+    @Test
+    fun `disconnect during WAITING_FOR_PLAYERS removes player`() {
+        gameService.handleJoin("Alice", "session-1")
+        gameService.handleDisconnect("session-1")
+
+        assertEquals(0, gameService.gameState.players.size)
+        assertEquals(GameStatus.WAITING_FOR_PLAYERS, gameService.gameState.status)
+    }
+
+    @Test
+    fun `disconnect during IN_PROGRESS sets status to FINISHED`() {
+        gameService.handleJoin("Alice", "session-1")
+        gameService.handleJoin("Bob", "session-2")
+
+        assertEquals(GameStatus.IN_PROGRESS, gameService.gameState.status)
+
+        gameService.handleDisconnect("session-1")
+
+        assertEquals(GameStatus.FINISHED, gameService.gameState.status)
+    }
+
+    @Test
+    fun `disconnect removes player units`() {
+        gameService.handleJoin("Alice", "session-1")
+        gameService.handleJoin("Bob", "session-2")
+
+        gameService.handleDisconnect("session-1")
+
+        val aliceUnits = gameService.gameState.units.filter { it.player == "Alice" }
+        assertEquals(0, aliceUnits.size)
+    }
+
+    @Test
+    fun `disconnect with unknown sessionId does nothing`() {
+        gameService.handleJoin("Alice", "session-1")
+        gameService.handleDisconnect("unknown-session")
+
+        assertEquals(1, gameService.gameState.players.size)
+    }
+
+    @Test
+    fun `disconnect sets currentTurn to null when IN_PROGRESS`() {
+        gameService.handleJoin("Alice", "session-1")
+        gameService.handleJoin("Bob", "session-2")
+
+        gameService.handleDisconnect("session-1")
+
+        assertNull(gameService.gameState.currentTurn)
+    }
+}


### PR DESCRIPTION


## Changes

* Added `handleDisconnect()` method to `GameService`
* Added `DisconnectHandler` with `@EventListener` for `SessionDisconnectEvent`
* Disconnect during `IN_PROGRESS` → `GameStatus.FINISHED` + Broadcast to `/topic/game`
* Disconnect during `WAITING_FOR_PLAYERS` → State stays open, player removed
* Thread-safe implementation with `synchronized(lock)`
* Added `DisconnectHandlerTest` with 6 unit tests for both disconnect scenarios
* Added `DisconnectHandlerComponentTest` with Mockito to test broadcast behavior
* Fixed deprecated `Enum.values()` → `Enum.entries` in `GameService`