### PR TITLE
Health Endpoint with live game info

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthController.kt
@@ -1,5 +1,6 @@
 package at.aau.hexabrawl.websocketserver.controller
 
+import at.aau.hexabrawl.websocketserver.model.GameService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
@@ -7,16 +8,23 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @RestController
-class HealthController {
+class HealthController(
+    private val gameService: GameService
+) {
 
     @GetMapping("/health")
     fun health(): ResponseEntity<Map<String, Any>> {
         val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        val state = gameService.getCurrentState()
+
         return ResponseEntity.ok(mapOf(
             "status" to "UP",
             "service" to "HexaBrawl Game Server",
             "version" to "1.0.0",
-            "timestamp" to LocalDateTime.now().format(formatter)
+            "timestamp" to LocalDateTime.now().format(formatter),
+            "gameStatus" to state.status.name,
+            "connectedPlayers" to state.players.size,
+            "maxPlayers" to GameService.MAX_PLAYERS
         ))
     }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthControllerTest.kt
@@ -1,12 +1,14 @@
 package at.aau.hexabrawl.websocketserver.controller
 
+import at.aau.hexabrawl.websocketserver.model.GameService
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 
 class HealthControllerTest {
 
-    private val controller = HealthController()
+    private val gameService = GameService()
+    private val controller = HealthController(gameService)
 
     @Test
     fun `health endpoint returns 200`() {
@@ -27,14 +29,32 @@ class HealthControllerTest {
     }
 
     @Test
+    fun `health endpoint returns version`() {
+        val response = controller.health()
+        assertEquals("1.0.0", response.body?.get("version"))
+    }
+
+    @Test
     fun `health endpoint returns timestamp`() {
         val response = controller.health()
         assertNotNull(response.body?.get("timestamp"))
     }
 
     @Test
-    fun `health endpoint returns version`() {
+    fun `health endpoint returns game status`() {
         val response = controller.health()
-        assertEquals("1.0.0", response.body?.get("version"))
+        assertEquals("WAITING_FOR_PLAYERS", response.body?.get("gameStatus"))
+    }
+
+    @Test
+    fun `health endpoint returns connected players count`() {
+        val response = controller.health()
+        assertEquals(0, response.body?.get("connectedPlayers"))
+    }
+
+    @Test
+    fun `health endpoint returns max players`() {
+        val response = controller.health()
+        assertEquals(2, response.body?.get("maxPlayers"))
     }
 }


### PR DESCRIPTION
Closes #41

## Änderungen
- GameService in HealthController eingebunden
- Health Endpoint zeigt jetzt live Spielstatus
- Anzahl verbundener Spieler wird angezeigt
- Maximale Spieleranzahl wird angezeigt
- 3 neue Unit Tests hinzugefügt

## Ergebnis
GET /health gibt zurück:
{
  "status": "UP",
  "service": "HexaBrawl Game Server",
  "version": "1.0.0",
  "timestamp": "2026-05-10 23:03:21",
  "gameStatus": "WAITING_FOR_PLAYERS",
  "connectedPlayers": 0,
  "maxPlayers": 2
}