### PR TITLE
fix: Broadcast nur bei bekanntem Spieler beim Disconnect

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandler.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandler.kt
@@ -16,9 +16,12 @@ class DisconnectHandler(
         val sessionId = event.sessionId
         println("DisconnectHandler: Session $sessionId disconnected")
 
+        val playerExists = gameService.gameState.players.any { it.sessionId == sessionId }
+
         val updatedState = gameService.handleDisconnect(sessionId)
 
-        // Broadcast an alle Spieler
-        messagingTemplate.convertAndSend("/topic/game", updatedState)
+        if (playerExists) {
+            messagingTemplate.convertAndSend("/topic/game", updatedState)
+        }
     }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerComponentTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerComponentTest.kt
@@ -39,4 +39,15 @@ class DisconnectHandlerComponentTest {
 
         assert(gameService.gameState.players.isEmpty())
     }
+
+    @Test
+    fun `handleDisconnect does not broadcast when player not found`() {
+        val event = Mockito.mock(SessionDisconnectEvent::class.java)
+        Mockito.`when`(event.sessionId).thenReturn("unknown-session")
+
+        handler.handleDisconnect(event)
+
+        Mockito.verifyNoInteractions(messagingTemplate)
+    }
+
 }


### PR DESCRIPTION
Closes #44

## Problem
Bisher wurde beim Disconnect immer ein Broadcast gesendet, auch wenn kein passender Spieler gefunden wurde.

## Lösung
Broadcast wird jetzt nur gesendet wenn der Spieler anhand der sessionId gefunden wurde.

## Änderungen
- `DisconnectHandler` prüft ob Spieler existiert vor dem Broadcast
- Neuer Test: kein Broadcast bei unbekannter sessionId

## Ergebnis
- Unnötige Broadcasts werden vermieden
- Bessere Performance und Korrektheit