### PR TITLE
Prepare GameService for multisession state handling

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -169,24 +169,29 @@ class GameService(
         return gameState
     }
 
-    fun handleDisconnect(sessionId: String): GameState = synchronized(lock) {
-        val player = gameState.players.find { it.sessionId == sessionId }
-            ?: return gameState
+    fun handleDisconnect(state: GameState, sessionId: String): GameState = synchronized(state.lock) {
+        val player = state.players.find { it.sessionId == sessionId }
+            ?: return state
 
         // Spieler und seine Units entfernen
-        gameState.players.remove(player)
-        gameState.units.removeIf { it.player == player.name }
+        state.players.remove(player)
+        state.units.removeIf { it.player == player.name }
 
         // Status anpassen
-        if (gameState.status == GameStatus.IN_PROGRESS) {
-            gameState.status = GameStatus.FINISHED
-            gameState.currentTurn = null
+        if (state.status == GameStatus.IN_PROGRESS) {
+            state.status = GameStatus.FINISHED
+            state.currentTurn = null
             println("Service: GAME FINISHED - ${player.name} disconnected")
         } else {
             println("Service: PLAYER LEFT - ${player.name} disconnected while waiting")
         }
 
-        return gameState
+        return state
     }
+
+    //Bridge Method handleDisconnect
+    fun handleDisconnect(
+        sessionId: String
+    ): GameState = handleDisconnect(this.gameState, sessionId)
 
 }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -8,7 +8,6 @@ class GameService(
 ) {
 
     val gameState = GameState()
-    val lock = Any()
 
     companion object {
         const val MAX_PLAYERS = 2
@@ -126,26 +125,35 @@ class GameService(
     }
 
     // WICHTIG FÜR TEST  Nur den aktuellen Stand lesen
-    fun getCurrentState(): GameState = synchronized(lock) {
-        return gameState
+    fun getCurrentState(state: GameState): GameState = synchronized(state.lock) {
+        return state
     }
+
+    //Bridge Method getCurrentState
+    fun getCurrentState(): GameState =
+        getCurrentState(this.gameState)
+
+
 
     // ALLES AUF NULL - Für /test/init
-    fun initializeGame(): GameState = synchronized(lock) {
-        gameState.players.clear()
-        gameState.units.clear()
-        gameState.currentTurn = null
-        gameState.status = GameStatus.WAITING_FOR_PLAYERS
+    fun initializeGame(state: GameState): GameState = synchronized(state.lock) {
+        state.players.clear()
+        state.units.clear()
+        state.currentTurn = null
+        state.status = GameStatus.WAITING_FOR_PLAYERS
         println("Service: GAME INITIALIZED - Everything cleared")
-        return gameState
+        return state
     }
 
+    //Bridge Method initializeGame
+    fun initializeGame(): GameState = initializeGame(this.gameState)
+
     // SPIELER BEHALTEN - Für /test/reset
-    fun resetToStartCondition(): GameState = synchronized(lock) {
-        gameState.units.clear() // Alte Einheiten löschen
+    fun resetToStartCondition(state: GameState): GameState = synchronized(state.lock) {
+        state.units.clear() // Alte Einheiten löschen
 
         // Für jeden verbliebenen Spieler eine neue Start-Einheit erstellen
-        gameState.players.forEachIndexed { index, player ->
+        state.players.forEachIndexed { index, player ->
             // Jedem Spieler eine feste Startposition zuordnen
             // Beispiel: Spieler 1 bei (0,0), Spieler 2 bei (5,5) - Werte an Grid anpassen!
             val startX = if (index == 0) 2 else 5
@@ -158,16 +166,19 @@ class GameService(
                     y = startY,
                     type = type
                 )
-                gameState.units.add(newUnit)
+                state.units.add(newUnit)
             }
         }
 
-        gameState.currentTurn = gameState.players.firstOrNull()?.name
-        gameState.status = GameStatus.IN_PROGRESS
+        state.currentTurn = state.players.firstOrNull()?.name
+        state.status = GameStatus.IN_PROGRESS
 
-        println("Service: Reset - Units for ${gameState.players} recreated at start positions.")
-        return gameState
+        println("Service: Reset - Units for ${state.players} recreated at start positions.")
+        return state
     }
+
+    //Bridge Method resetToStartCondition
+    fun resetToStartCondition(): GameState = resetToStartCondition(this.gameState)
 
     fun handleDisconnect(state: GameState, sessionId: String): GameState = synchronized(state.lock) {
         val player = state.players.find { it.sessionId == sessionId }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -61,27 +61,26 @@ class GameService(
     fun handleJoin(
         playerName: String,
         sessionId: String = ""
-    ): GameState =
-        handleJoin(this.gameState, playerName, sessionId)
+    ): GameState = handleJoin(this.gameState, playerName, sessionId)
 
-    fun handleMove(move: Move): GameState = synchronized(lock) {
-        if (gameState.status != GameStatus.IN_PROGRESS) return gameState
-        if (move.player != gameState.currentTurn) return gameState
+    fun handleMove(state: GameState, move: Move): GameState = synchronized(state.lock) {
+        if (state.status != GameStatus.IN_PROGRESS) return state
+        if (move.player != state.currentTurn) return state
 
-        val unit = gameState.units.firstOrNull {
+        val unit = state.units.firstOrNull {
             it.player == move.player &&
                     it.type == move.type &&
                     it.type != UnitType.SKELETON &&
                     it.x == move.fromX &&
                     it.y == move.fromY
-        } ?: return gameState
+        } ?: return state
 
-        val friendlyOnTarget = gameState.units.any {
+        val friendlyOnTarget = state.units.any {
             it.x == move.toX && it.y == move.toY && it.player == move.player
         }
-        if (friendlyOnTarget) return gameState
+        if (friendlyOnTarget) return state
 
-        val enemyOnTarget = gameState.units.firstOrNull {
+        val enemyOnTarget = state.units.firstOrNull {
             it.x == move.toX && it.y == move.toY &&
                     it.player != move.player &&
                     it.type != UnitType.SKELETON
@@ -90,24 +89,40 @@ class GameService(
         if (enemyOnTarget != null) {
             val result = combatService.resolveCombat(unit, enemyOnTarget)
             combatService.applyCombatResult(result, unit, enemyOnTarget)
-            if (!result.defenderSurvived) gameState.units.remove(enemyOnTarget)
-            if (!result.attackerSurvived) gameState.units.remove(unit)
-            switchTurn()
-            return gameState
+            if (!result.defenderSurvived) state.units.remove(enemyOnTarget)
+            if (!result.attackerSurvived) state.units.remove(unit)
+            switchTurn(state)
+            return state
         }
 
         unit.x = move.toX
         unit.y = move.toY
 
-        val (p1, p2) = gameState.players
-        gameState.currentTurn = if (gameState.currentTurn == p1.name) p2.name else p1.name
+        val (p1, p2) = state.players
+        state.currentTurn = if (state.currentTurn == p1.name) p2.name else p1.name
 
-        return gameState
+        return state
     }
+
+    //Bridge Method handleMove
+    fun handleMove(
+        move: Move
+    ): GameState = handleMove(this.gameState, move)
 
     private fun switchTurn() {
         val (p1, p2) = gameState.players
         gameState.currentTurn = if (gameState.currentTurn == p1.name) p2.name else p1.name
+    }
+
+    private fun switchTurn(state: GameState) {
+
+        val (p1, p2) = state.players
+
+        state.currentTurn =
+            if (state.currentTurn == p1.name)
+                p2.name
+            else
+                p1.name
     }
 
     // WICHTIG FÜR TEST  Nur den aktuellen Stand lesen

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -108,10 +108,6 @@ class GameService(
         move: Move
     ): GameState = handleMove(this.gameState, move)
 
-    private fun switchTurn() {
-        val (p1, p2) = gameState.players
-        gameState.currentTurn = if (gameState.currentTurn == p1.name) p2.name else p1.name
-    }
 
     private fun switchTurn(state: GameState) {
 

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -14,19 +14,19 @@ class GameService(
         const val MAX_PLAYERS = 2
     }
 
-    fun handleJoin(playerName: String, sessionId:String=""): GameState = synchronized(lock) {
+    fun handleJoin(state: GameState, playerName: String, sessionId:String=""): GameState = synchronized(state.lock) {
         // Spieler hinzufügen, falls noch nicht vorhanden und Platz ist
 
-        if (!gameState.players.any{it.name == playerName} && gameState.players.size < MAX_PLAYERS) {
-            val color = if (gameState.players.isEmpty()) PlayerColor.RED else PlayerColor.BLUE
-            gameState.players.add(Player(playerName, sessionId,color))
+        if (!state.players.any{it.name == playerName} && state.players.size < MAX_PLAYERS) {
+            val color = if (state.players.isEmpty()) PlayerColor.RED else PlayerColor.BLUE
+            state.players.add(Player(playerName, sessionId,color))
             println("JOIN: $playerName")
         }
 
         // Automatischer Start bei 2 Spielern
-        if (gameState.players.size == 2 && gameState.units.isEmpty()) {
-            val p1 = gameState.players[0]
-            val p2 = gameState.players[1]
+        if (state.players.size == 2 && state.units.isEmpty()) {
+            val p1 = state.players[0]
+            val p2 = state.players[1]
 
             // Start-Einheiten setzen
             val startPositionsP1 = listOf(
@@ -45,16 +45,24 @@ class GameService(
                 val (x1, y1) = startPositionsP1[index]
                 val (x2, y2) = startPositionsP2[index]
 
-                gameState.units.add(GameUnit(p1.name, x1, y1, type))
-                gameState.units.add(GameUnit(p2.name, x2, y2, type))
+                state.units.add(GameUnit(p1.name, x1, y1, type))
+                state.units.add(GameUnit(p2.name, x2, y2, type))
             }
 
-            gameState.currentTurn = p1.name
-            gameState.status = GameStatus.IN_PROGRESS
+            state.currentTurn = p1.name
+            state.status = GameStatus.IN_PROGRESS
             println("Service: GAME STARTED")
         }
-        return gameState
+        return state
+
     }
+
+    //Bridge Method handleJoin
+    fun handleJoin(
+        playerName: String,
+        sessionId: String = ""
+    ): GameState =
+        handleJoin(this.gameState, playerName, sessionId)
 
     fun handleMove(move: Move): GameState = synchronized(lock) {
         if (gameState.status != GameStatus.IN_PROGRESS) return gameState

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameState.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameState.kt
@@ -1,4 +1,5 @@
 package at.aau.hexabrawl.websocketserver.model
+import com.fasterxml.jackson.annotation.JsonIgnore
 
 enum class GameStatus {
     WAITING_FOR_PLAYERS,
@@ -12,3 +13,7 @@ data class GameState(
     var currentTurn: String? = null,
     var status: GameStatus = GameStatus.WAITING_FOR_PLAYERS
 )
+{
+    @JsonIgnore
+    val lock: Any = Any()
+}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
@@ -195,4 +195,49 @@ class GameModelTest {
         assertEquals(3, movedUnit?.x)
         assertEquals(3, movedUnit?.y)
     }
+
+    @Test
+    fun `handleDisconnect only modifies provided state`() {
+
+        val gameService = GameService(CombatService())
+
+        val state1 = GameState()
+        val state2 = GameState()
+
+        gameService.handleJoin(
+            state1,
+            "Josef",
+            "s1"
+        )
+
+        gameService.handleDisconnect(
+            state1,
+            "s1"
+        )
+
+        assertTrue(state1.players.isEmpty())
+        assertTrue(state2.players.isEmpty())
+
+        assertEquals(
+            GameStatus.WAITING_FOR_PLAYERS,
+            state2.status
+        )
+    }
+
+    @Test
+    fun `legacy handleDisconnect bridge still uses gameState`() {
+
+        val gameService = GameService(CombatService())
+
+        gameService.handleJoin(
+            "Josef",
+            "s1"
+        )
+
+        gameService.handleDisconnect("s1")
+
+        assertTrue(
+            gameService.gameState.players.isEmpty()
+        )
+    }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
@@ -1,8 +1,6 @@
 package at.aau.hexabrawl.websocketserver.model
 
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
 class GameModelTest {
@@ -18,43 +16,43 @@ class GameModelTest {
             toY = 4
         )
 
-        Assertions.assertEquals("Alice", move.player)
-        Assertions.assertEquals(UnitType.INFANTRY, move.type)
-        Assertions.assertEquals(1, move.fromX)
-        Assertions.assertEquals(2, move.fromY)
-        Assertions.assertEquals(3, move.toX)
-        Assertions.assertEquals(4, move.toY)
+        assertEquals("Alice", move.player)
+        assertEquals(UnitType.INFANTRY, move.type)
+        assertEquals(1, move.fromX)
+        assertEquals(2, move.fromY)
+        assertEquals(3, move.toX)
+        assertEquals(4, move.toY)
     }
 
     @Test
     fun `move default constructor coverage`() {
         val move = Move()
 
-        Assertions.assertEquals("", move.player)
-        Assertions.assertEquals(UnitType.INFANTRY, move.type)
-        Assertions.assertEquals(0, move.fromX)
-        Assertions.assertEquals(0, move.fromY)
-        Assertions.assertEquals(0, move.toX)
-        Assertions.assertEquals(0, move.toY)
+        assertEquals("", move.player)
+        assertEquals(UnitType.INFANTRY, move.type)
+        assertEquals(0, move.fromX)
+        assertEquals(0, move.fromY)
+        assertEquals(0, move.toX)
+        assertEquals(0, move.toY)
     }
 
     @Test
     fun `game unit covers all properties`() {
         val unit = GameUnit("Bob", 5, 6, UnitType.INFANTRY)
 
-        Assertions.assertEquals("Bob", unit.player)
-        Assertions.assertEquals(5, unit.x)
-        Assertions.assertEquals(6, unit.y)
+        assertEquals("Bob", unit.player)
+        assertEquals(5, unit.x)
+        assertEquals(6, unit.y)
     }
 
     @Test
     fun `game unit constructor`() {
         val unit = GameUnit("", 0, 0, UnitType.INFANTRY)
 
-        Assertions.assertEquals("", unit.player)
-        Assertions.assertEquals(0, unit.x)
-        Assertions.assertEquals(0, unit.y)
-        Assertions.assertEquals(UnitType.INFANTRY, unit.type)
+        assertEquals("", unit.player)
+        assertEquals(0, unit.x)
+        assertEquals(0, unit.y)
+        assertEquals(UnitType.INFANTRY, unit.type)
     }
 
     @Test
@@ -64,9 +62,9 @@ class GameModelTest {
         state.units.add(GameUnit("Alice", 1, 1, UnitType.INFANTRY))
         state.currentTurn = "Alice"
 
-        Assertions.assertEquals(1, state.players.size)
-        Assertions.assertEquals(1, state.units.size)
-        Assertions.assertEquals("Alice", state.currentTurn)
+        assertEquals(1, state.players.size)
+        assertEquals(1, state.units.size)
+        assertEquals("Alice", state.currentTurn)
     }
 
     @Test
@@ -80,15 +78,15 @@ class GameModelTest {
     @Test
     fun `ErrorMessage and ErrorCode coverage`() {
         val error = ErrorMessage(ErrorCode.GAME_FULL, "Spiel ist voll")
-        Assertions.assertEquals(ErrorCode.GAME_FULL, error.errorCode)
-        Assertions.assertEquals("Spiel ist voll", error.message)
+        assertEquals(ErrorCode.GAME_FULL, error.errorCode)
+        assertEquals("Spiel ist voll", error.message)
     }
 
     @Test
     fun `StompMessage coverage`() {
         val msg = StompMessage("Server", "Test-Inhalt")
-        Assertions.assertEquals("Server", msg.from)
-        Assertions.assertEquals("Test-Inhalt", msg.text)
+        assertEquals("Server", msg.from)
+        assertEquals("Test-Inhalt", msg.text)
     }
 
     @Test
@@ -240,4 +238,60 @@ class GameModelTest {
             gameService.gameState.players.isEmpty()
         )
     }
+
+    @Test
+    fun `initializeGame only modifies provided state`() {
+
+        val gameService = GameService(CombatService())
+
+        val state1 = GameState()
+        val state2 = GameState()
+
+        gameService.handleJoin(state1, "Josef", "s1")
+
+        gameService.initializeGame(state1)
+
+        assertTrue(state1.players.isEmpty())
+
+        assertTrue(state2.players.isEmpty())
+
+        assertTrue(state2.units.isEmpty())
+    }
+
+    @Test
+    fun `resetToStartCondition only modifies provided state`() {
+
+        val gameService = GameService(CombatService())
+
+        val state1 = GameState()
+        val state2 = GameState()
+
+        gameService.handleJoin(state1, "Josef", "s1")
+        gameService.handleJoin(state1, "Marie", "s2")
+
+        gameService.resetToStartCondition(state1)
+
+        // Spieler bleiben erhalten
+        assertEquals(2, state1.players.size)
+
+        // Units existieren weiterhin
+        assertFalse(state1.units.isEmpty())
+
+        // Zweiter State bleibt unverändert
+        assertTrue(state2.players.isEmpty())
+        assertTrue(state2.units.isEmpty())
+    }
+
+    @Test
+    fun `getCurrentState returns provided state`() {
+
+        val gameService = GameService(CombatService())
+
+        val state1 = GameState()
+
+        val result = gameService.getCurrentState(state1)
+
+        assertSame(state1, result)
+    }
+
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
@@ -89,4 +89,48 @@ class GameModelTest {
         Assertions.assertEquals("Server", msg.from)
         Assertions.assertEquals("Test-Inhalt", msg.text)
     }
+
+    @Test
+    fun `handleJoin only modifies provided state`() {
+
+        val gameService = GameService(CombatService())
+
+        val state1 = GameState()
+        val state2 = GameState()
+
+        gameService.handleJoin(
+            state1,
+            "Alice",
+            "session-1"
+        )
+
+        assertEquals(1, state1.players.size)
+        assertEquals(0, state2.players.size)
+
+        assertEquals(
+            "Alice",
+            state1.players[0].name
+        )
+    }
+
+    @Test
+    fun `legacy handleJoin bridge still uses gameState`() {
+
+        val gameService = GameService(CombatService())
+
+        gameService.handleJoin(
+            "Alice",
+            "session-1"
+        )
+
+        assertEquals(
+            1,
+            gameService.gameState.players.size
+        )
+
+        assertEquals(
+            "Alice",
+            gameService.gameState.players[0].name
+        )
+    }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
@@ -2,6 +2,7 @@ package at.aau.hexabrawl.websocketserver.model
 
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class GameModelTest {
@@ -100,7 +101,7 @@ class GameModelTest {
 
         gameService.handleJoin(
             state1,
-            "Alice",
+            "Josef",
             "session-1"
         )
 
@@ -108,7 +109,7 @@ class GameModelTest {
         assertEquals(0, state2.players.size)
 
         assertEquals(
-            "Alice",
+            "Josef",
             state1.players[0].name
         )
     }
@@ -119,7 +120,7 @@ class GameModelTest {
         val gameService = GameService(CombatService())
 
         gameService.handleJoin(
-            "Alice",
+            "Josef",
             "session-1"
         )
 
@@ -129,8 +130,69 @@ class GameModelTest {
         )
 
         assertEquals(
-            "Alice",
+            "Josef",
             gameService.gameState.players[0].name
         )
+    }
+
+    @Test
+    fun `handleMove only modifies provided state`() {
+        val gameService = GameService(CombatService())
+
+        val state1 = GameState()
+        val state2 = GameState()
+
+        gameService.handleJoin(state1, "Josef", "s1")
+        gameService.handleJoin(state1, "Marie", "s2")
+
+        val move = Move(
+            "Josef",
+            UnitType.INFANTRY,
+            3,
+            2,
+            3,
+            3
+        )
+
+        gameService.handleMove(state1, move)
+
+        val movedUnit =
+            state1.units.find {
+                it.player == "Josef" &&
+                        it.type == UnitType.INFANTRY
+            }
+
+        assertEquals(3, movedUnit?.x)
+        assertEquals(3, movedUnit?.y)
+
+        assertTrue(state2.units.isEmpty())
+    }
+
+    @Test
+    fun `legacy handleMove bridge still uses gameState`() {
+        val gameService = GameService(CombatService())
+
+        gameService.handleJoin("Josef", "s1")
+        gameService.handleJoin("Marie", "s2")
+
+        val move = Move(
+            "Josef",
+            UnitType.INFANTRY,
+            3,
+            2,
+            3,
+            3
+        )
+
+        gameService.handleMove(move)
+
+        val movedUnit =
+            gameService.gameState.units.find {
+                it.player == "Josef" &&
+                        it.type == UnitType.INFANTRY
+            }
+
+        assertEquals(3, movedUnit?.x)
+        assertEquals(3, movedUnit?.y)
     }
 }


### PR DESCRIPTION
### Summary

This PR refactors `GameService` to prepare the backend for future multisession support.

The service logic is now state-based instead of implicitly operating on the global `gameState` instance.

### Changes

* Added per-state synchronization via:

  * `GameState.lock`
* Refactored the following methods to accept `state: GameState`:

  * `handleJoin`
  * `handleMove`
  * `handleDisconnect`
  * `initializeGame`
  * `resetToStartCondition`
  * `getCurrentState`
* Added legacy bridge overloads to preserve backward compatibility
* Refactored internal helper methods (e.g. `switchTurn`)
* Removed obsolete global `GameService.lock`

### Tests

* All existing tests remain green
* Added state-isolation tests proving that methods only modify the provided `GameState`
* Verified backward compatibility through existing controller/service tests

### Result

This PR is behavior-neutral and prepares the service layer for the upcoming multisession room architecture.
