### PR TITLE
Fix #59: Move-Broadcast wird bei gültigen Zügen nicht mehr unterdrückt und Broadcast Tests hinzugefügt

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -77,9 +77,10 @@ class WebSocketBrokerController(
             return null
         }
 
+        val turnBefore = stateBefore.currentTurn
         val stateAfter = gameService.handleMove(move)
 
-        if (stateAfter === stateBefore) {
+        if (stateAfter.currentTurn == turnBefore) {
             sendError(sessionId, ErrorCode.INVALID_MOVE, "Dieser Zug ist laut Regeln ungültig.")
             return null
         }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -356,4 +356,45 @@ class WebSocketBrokerControllerTest {
             argThat { it is ErrorMessage && it.errorCode == ErrorCode.INVALID_MOVE }
         )
     }
+
+    @Test
+    fun `broadcasts new state on success`() {
+        controller.handleJoin("Alice", "session-1")
+        controller.handleJoin("Bob", "session-2")
+
+        val move = Move(
+            player = "Alice",
+            type = UnitType.INFANTRY,
+            fromX = 3,
+            fromY = 2,
+            toX = 3,
+            toY = 3
+        )
+
+        val result = controller.move(move, headerAccessor)
+
+        assertNotNull(result)
+
+        verifyNoInteractions(messagingTemplate)
+    }
+
+    @Test
+    fun `valid move switches turn`() {
+        controller.handleJoin("Alice", "session-1")
+        controller.handleJoin("Bob", "session-2")
+
+        val move = Move(
+            player = "Alice",
+            type = UnitType.INFANTRY,
+            fromX = 3,
+            fromY = 2,
+            toX = 3,
+            toY = 3
+        )
+        val result = controller.move(move, headerAccessor)
+
+        assertNotNull(result)
+
+        assertEquals("Bob", result?.currentTurn)
+    }
 }


### PR DESCRIPTION
**Problem:**
Gültige Spielzüge wurden im WebSocketBrokerController fälschlicherweise abgelehnt und nicht an /topic/game gebroadcastet. Die Ursache war der Vergleich if (stateAfter === stateBefore). Da der GameService das bestehende GameState-Singleton im Arbeitsspeicher mutiert anstatt ein neues Objekt zu erzeugen, war dieser Referenzvergleich immer true.

**Lösung:**
- Den === Operator entfernt.
- Logische Validierung eingebaut: Wir speichern den currentTurn vor Ausführung des Zuges. Ist der Spieler nach dem handleMove() immer noch an der Reihe, war der Zug laut Spielregeln ungültig und es wird ein INVALID_MOVE Error via Point-to-Point gesendet.

**Tests:**
- Der bestehende Test für INVALID_MOVE ist weiterhin grün.
- Neuer Test: broadcasts new state on success verifiziert, dass bei gültigen Zügen das result nicht null ist und das SimpMessagingTemplate keinen Error verschickt.
- Neuer Test: valid move switches turn stellt sicher, dass der aktive Spieler nach einem korrekten Zug wechselt.

Closes #59 