### PR TITLE
Feat #72: Startkapital (Gold) für neue Spieler implementieren

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -11,7 +11,7 @@ class GameService(
 
     companion object {
         const val MAX_PLAYERS = 2
-        const val STARTING_GOLD = 10
+        const val STARTING_GOLD = 6
     }
 
     fun handleJoin(state: GameState, playerName: String, sessionId:String=""): GameState = synchronized(state.lock) {

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -11,6 +11,7 @@ class GameService(
 
     companion object {
         const val MAX_PLAYERS = 2
+        const val STARTING_GOLD = 10
     }
 
     fun handleJoin(state: GameState, playerName: String, sessionId:String=""): GameState = synchronized(state.lock) {
@@ -18,7 +19,7 @@ class GameService(
 
         if (!state.players.any{it.name == playerName} && state.players.size < MAX_PLAYERS) {
             val color = if (state.players.isEmpty()) PlayerColor.RED else PlayerColor.BLUE
-            state.players.add(Player(playerName, sessionId,color))
+            state.players.add(Player(playerName, sessionId,color, STARTING_GOLD))
             println("JOIN: $playerName")
         }
 

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Player.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Player.kt
@@ -4,6 +4,6 @@ package at.aau.hexabrawl.websocketserver.model
 data class Player (
     val name : String = "",
     val sessionId : String = "",
-    val color: PlayerColor = PlayerColor.RED
-
+    val color: PlayerColor = PlayerColor.RED,
+    var gold: Int = 0
 ){}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -17,7 +17,7 @@ class GameServiceTest {
         // 1. Erster Join
         gameService.handleJoin("Alice")
         val stateAfterAlice = gameService.getCurrentState()
-        assertThat(stateAfterAlice.players).containsExactly(Player("Alice"))
+        assertThat(stateAfterAlice.players).containsExactly(Player("Alice", gold = GameService.STARTING_GOLD))
 
         // 2. Doppelter Join (Alice versucht nochmal) -> Darf nichts ändern
         gameService.handleJoin("Alice")
@@ -260,4 +260,12 @@ class GameServiceTest {
         assertThat(updated.currentTurn).isEqualTo("Bob")
     }
 
+    @Test
+    fun `player receives starting gold on join`() {
+        gameService.handleJoin("Alice")
+
+        val player = gameService.getCurrentState().players.first { it.name == "Alice" }
+
+        assertThat(player.gold).isEqualTo(GameService.STARTING_GOLD)
+    }
 }


### PR DESCRIPTION
**Problem / Zweck**

Als Grundlage für das neue Wirtschaftssystem benötigen Spieler ein Konto (gold), das beim Spielstart initialisiert wird, damit in den darauf aufbauenden Issues Transaktionen und Unterhaltskosten berechnet werden können.

**Lösung**
- Die Datenklasse Player wurde um das Attribut var gold: Int (Default 0) erweitert.
- Im GameService wurde die Konstante STARTING_GOLD = 10 definiert.
- Beim Joinen eines Spielers wird das Startkapital nun automatisch zugewiesen.
- Das Attribut wird durch das Standard-Jackson-Verhalten automatisch im GameState-JSON für das Frontend mit-serialisiert.

Closes #72 