### PR TITLE
Add GameMode enum and Room data class

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameMode.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameMode.kt
@@ -1,0 +1,17 @@
+package at.aau.hexabrawl.websocketserver.model
+
+/**
+ * Defines the available game modes with their respective maximum player counts.
+ *
+ * @property maxPlayers Maximum number of players allowed in this game mode.
+ */
+enum class GameMode(val maxPlayers: Int) {
+    /** 1v1 mode for two players. */
+    DUAL_VALLEY(2),
+
+    /** Three-player mode. */
+    TRIAD_OUTPOST(3),
+
+    /** Four-player mode. */
+    BATTLEFIELD_PEAKS(4)
+}

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Room.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Room.kt
@@ -14,14 +14,13 @@ data class Room(
     val roomId: String,
     val joinCode: String,
     val mode: GameMode,
-    @JsonIgnore
-    val state: GameState = GameState()
+    val gameState: GameState = GameState()
 ) {
     /** Current game status derived from the room's game state. */
-    val status: GameStatus get() = state.status
+    val status: GameStatus get() = gameState.status
 
     /** List of player names currently in this room. */
-    val players: List<String> get() = state.players.map { it.name }
+    val players: List<String> get() = gameState.players.map { it.name }
 
     /** Maximum number of players allowed in this room. */
     val maxPlayers: Int get() = mode.maxPlayers

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Room.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Room.kt
@@ -1,0 +1,28 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+
+/**
+ * Represents a single game room with its own isolated game state.
+ *
+ * @property roomId Unique identifier for this room (UUID format).
+ * @property joinCode Short 6-character code players can use to join.
+ * @property mode The game mode determining max players and rules.
+ * @property state The isolated game state for this room.
+ */
+data class Room(
+    val roomId: String,
+    val joinCode: String,
+    val mode: GameMode,
+    @JsonIgnore
+    val state: GameState = GameState()
+) {
+    /** Current game status derived from the room's game state. */
+    val status: GameStatus get() = state.status
+
+    /** List of player names currently in this room. */
+    val players: List<String> get() = state.players.map { it.name }
+
+    /** Maximum number of players allowed in this room. */
+    val maxPlayers: Int get() = mode.maxPlayers
+}

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Room.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Room.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
  * @property roomId Unique identifier for this room (UUID format).
  * @property joinCode Short 6-character code players can use to join.
  * @property mode The game mode determining max players and rules.
- * @property state The isolated game state for this room.
+ * @property gameState The isolated game state for this room.
  */
 data class Room(
     val roomId: String,

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Room.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Room.kt
@@ -1,7 +1,5 @@
 package at.aau.hexabrawl.websocketserver.model
 
-import com.fasterxml.jackson.annotation.JsonIgnore
-
 /**
  * Represents a single game room with its own isolated game state.
  *

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomTest.kt
@@ -57,14 +57,14 @@ class RoomTest {
     @Test
     fun `Room players list reflects game state players`() {
         val room = Room("room-1", "ABC123", GameMode.DUAL_VALLEY)
-        room.state.players.add(Player("Alice", "s1", PlayerColor.RED))
+        room.gameState.players.add(Player("Alice", "s1", PlayerColor.RED))
         assertEquals(listOf("Alice"), room.players)
     }
 
     @Test
     fun `Room status reflects game state status`() {
         val room = Room("room-1", "ABC123", GameMode.DUAL_VALLEY)
-        room.state.status = GameStatus.IN_PROGRESS
+        room.gameState.status = GameStatus.IN_PROGRESS
         assertEquals(GameStatus.IN_PROGRESS, room.status)
     }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomTest.kt
@@ -1,0 +1,70 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class RoomTest {
+
+    // ===== GameMode Tests =====
+
+    @Test
+    fun `DUAL_VALLEY has max 2 players`() {
+        assertEquals(2, GameMode.DUAL_VALLEY.maxPlayers)
+    }
+
+    @Test
+    fun `TRIAD_OUTPOST has max 3 players`() {
+        assertEquals(3, GameMode.TRIAD_OUTPOST.maxPlayers)
+    }
+
+    @Test
+    fun `BATTLEFIELD_PEAKS has max 4 players`() {
+        assertEquals(4, GameMode.BATTLEFIELD_PEAKS.maxPlayers)
+    }
+
+    @Test
+    fun `GameMode has exactly 3 values`() {
+        assertEquals(3, GameMode.entries.size)
+    }
+
+    // ===== Room Tests =====
+
+    @Test
+    fun `Room is created with correct roomId and joinCode`() {
+        val room = Room("room-1", "ABC123", GameMode.DUAL_VALLEY)
+        assertEquals("room-1", room.roomId)
+        assertEquals("ABC123", room.joinCode)
+    }
+
+    @Test
+    fun `Room starts with WAITING_FOR_PLAYERS status`() {
+        val room = Room("room-1", "ABC123", GameMode.DUAL_VALLEY)
+        assertEquals(GameStatus.WAITING_FOR_PLAYERS, room.status)
+    }
+
+    @Test
+    fun `Room starts with empty player list`() {
+        val room = Room("room-1", "ABC123", GameMode.DUAL_VALLEY)
+        assertTrue(room.players.isEmpty())
+    }
+
+    @Test
+    fun `Room maxPlayers matches GameMode`() {
+        val room = Room("room-1", "ABC123", GameMode.TRIAD_OUTPOST)
+        assertEquals(3, room.maxPlayers)
+    }
+
+    @Test
+    fun `Room players list reflects game state players`() {
+        val room = Room("room-1", "ABC123", GameMode.DUAL_VALLEY)
+        room.state.players.add(Player("Alice", "s1", PlayerColor.RED))
+        assertEquals(listOf("Alice"), room.players)
+    }
+
+    @Test
+    fun `Room status reflects game state status`() {
+        val room = Room("room-1", "ABC123", GameMode.DUAL_VALLEY)
+        room.state.status = GameStatus.IN_PROGRESS
+        assertEquals(GameStatus.IN_PROGRESS, room.status)
+    }
+}


### PR DESCRIPTION
Closes #79

## Änderungen
- `GameMode` Enum hinzugefügt mit DUAL_VALLEY(2), TRIAD_OUTPOST(3), BATTLEFIELD_PEAKS(4)
- `Room` Datenklasse hinzugefügt mit isoliertem GameState und joinCode
- KDocs für alle neuen Klassen vorhanden
- 10 Unit Tests hinzugefügt

## Details
Sub-Issue von #51 — Multisession Management