### PR TITLE
Feat #73: Unterhaltsmechanik und Insolvenz implementieren

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -247,7 +247,8 @@ class GameService(
 
     private fun applyUpkeep(state: GameState) {
         state.players.forEach { player ->
-            val playerUnits = state.units.filter { it.player == player.name }
+            // Skelette herausfiltern, damit sie in Zukunft keinen Unterhalt mehr kosten
+            val playerUnits = state.units.filter { it.player == player.name && it.type != UnitType.SKELETON }
             val unitCount = playerUnits.size
 
             // Unterhalt berechnen (Arithmetische Reihe: 1. Einheit kostet 3, jede weitere +1)
@@ -257,12 +258,13 @@ class GameService(
                 // Normaler Abzug
                 player.gold -= upkeep
             } else {
-                // Insolvenz: alle Truppen werden restlos entfernt
+                // Insolvenz: Gold auf 0, alle lebenden Truppen werden zu Skeletten!
                 player.gold = 0
-                state.units.removeAll(playerUnits.toSet())
+                playerUnits.forEach { it.type = UnitType.SKELETON }
             }
         }
-        // Prüfen, ob durch Insolvenz ein Spieler alle Einheiten verloren hat (Win-Condition)
+
+        // Prüfen, ob durch Insolvenz ein Spieler alle lebenden Einheiten verloren hat (Win-Condition)
         checkWinCondition(state)
     }
 }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -99,8 +99,7 @@ class GameService(
         unit.x = move.toX
         unit.y = move.toY
 
-        val (p1, p2) = state.players
-        state.currentTurn = if (state.currentTurn == p1.name) p2.name else p1.name
+        switchTurn(state)
 
         checkWinCondition(state)
         return state
@@ -157,6 +156,11 @@ class GameService(
                 p2.name
             else
                 p1.name
+
+        // Wenn der Zug wieder bei Spieler 1 (p1) ist, ist eine Runde vorbei
+        if (state.currentTurn == p1.name) {
+            applyUpkeep(state)
+        }
     }
 
     // WICHTIG FÜR TEST  Nur den aktuellen Stand lesen
@@ -241,4 +245,24 @@ class GameService(
         sessionId: String
     ): GameState = handleDisconnect(this.gameState, sessionId)
 
+    private fun applyUpkeep(state: GameState) {
+        state.players.forEach { player ->
+            val playerUnits = state.units.filter { it.player == player.name }
+            val unitCount = playerUnits.size
+
+            // Unterhalt berechnen (Arithmetische Reihe: 1. Einheit kostet 3, jede weitere +1)
+            val upkeep = (0 until unitCount).sumOf { 3 + it }
+
+            if (player.gold >= upkeep) {
+                // Normaler Abzug
+                player.gold -= upkeep
+            } else {
+                // Insolvenz: alle Truppen werden restlos entfernt
+                player.gold = 0
+                state.units.removeAll(playerUnits.toSet())
+            }
+        }
+        // Prüfen, ob durch Insolvenz ein Spieler alle Einheiten verloren hat (Win-Condition)
+        checkWinCondition(state)
+    }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -139,6 +139,9 @@ class WebSocketBrokerControllerTest {
         controller.handleJoin("Alice", "session-1")
         controller.handleJoin("Bob", "session-2")
 
+        // Gold geben, damit sie nach der Runde nicht pleitegehen
+        gameService.getCurrentState().players.forEach { it.gold = 100 }
+
         // First move
         controller.handleMove(
             Move("Alice", UnitType.INFANTRY, 3, 2, 3, 3)
@@ -212,6 +215,9 @@ class WebSocketBrokerControllerTest {
     fun `turn switches after valid move`() {
         controller.handleJoin("Alice", "session-1")
         controller.handleJoin("Bob", "session-2")
+
+        // Gold geben, damit sie nach der Runde nicht pleitegehen
+        gameService.getCurrentState().players.forEach { it.gold = 100 }
 
         // Alice move
         val state1 = controller.handleMove(

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -268,4 +268,94 @@ class GameServiceTest {
 
         assertThat(player.gold).isEqualTo(GameService.STARTING_GOLD)
     }
+
+    @Test
+    fun `test applyUpkeep - normaler Abzug (AC6)`() {
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+
+        val state = gameService.getCurrentState()
+        // Beide Spieler bekommen genug Gold
+        state.players.forEach { it.gold = 20 }
+
+        // Zug Alice
+        val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY, aliceInf.x, aliceInf.y, 0, 0))
+
+        // Zug Bob -> Beendet die Runde, applyUpkeep wird getriggert
+        val bobInf = state.units.first { it.player == "Bob" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, 1, 1))
+
+        // Bei 3 Start-Einheiten kostet der Unterhalt 12 Gold (3+4+5). 20 - 12 = 8.
+        assertThat(state.players.first { it.name == "Alice" }.gold).isEqualTo(8)
+        assertThat(state.players.first { it.name == "Bob" }.gold).isEqualTo(8)
+    }
+
+    @Test
+    fun `test applyUpkeep - Grenzfall exakt 0 (AC6)`() {
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+
+        val state = gameService.getCurrentState()
+        // Spieler bekommen exakt das Gold für den Unterhalt von 3 Einheiten
+        state.players.forEach { it.gold = 12 }
+
+        val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY, aliceInf.x, aliceInf.y, 0, 0))
+
+        val bobInf = state.units.first { it.player == "Bob" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, 1, 1))
+
+        val alice = state.players.first { it.name == "Alice" }
+        // Gold muss genau auf 0 fallen, aber die Einheiten müssen bleiben
+        assertThat(alice.gold).isEqualTo(0)
+        assertThat(state.units.count { it.player == "Alice" }).isEqualTo(3)
+    }
+
+    @Test
+    fun `test applyUpkeep - Insolvenz mit Unit-Verlust (AC6)`() {
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+
+        val state = gameService.getCurrentState()
+        // Alice hat 1 Gold zu wenig. Bob hat genug.
+        state.players.first { it.name == "Alice" }.gold = 11
+        state.players.first { it.name == "Bob" }.gold = 20
+
+        val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY, aliceInf.x, aliceInf.y, 0, 0))
+
+        val bobInf = state.units.first { it.player == "Bob" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, 1, 1))
+
+        val alice = state.players.first { it.name == "Alice" }
+        // Alice geht bankrott: Gold = 0, alle Einheiten gnadenlos gelöscht
+        assertThat(alice.gold).isEqualTo(0)
+        assertThat(state.units.count { it.player == "Alice" }).isEqualTo(0)
+    }
+
+    @Test
+    fun `test applyUpkeep - Insolvenz loest Win-Condition aus (AC6)`() {
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+
+        val state = gameService.getCurrentState()
+        // Alice hat zu wenig Geld und geht pleite
+        state.players.first { it.name == "Alice" }.gold = 5
+        state.players.first { it.name == "Bob" }.gold = 20
+
+        val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY, aliceInf.x, aliceInf.y, 0, 0))
+
+        val bobInf = state.units.first { it.player == "Bob" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, 1, 1))
+
+        // Da Alice durch Insolvenz 0 Einheiten hat, muss Bob sofort gewinnen
+        assertThat(state.status).isEqualTo(GameStatus.FINISHED)
+        assertThat(state.winner).isEqualTo("Bob")
+    }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -270,7 +270,7 @@ class GameServiceTest {
     }
 
     @Test
-    fun `test applyUpkeep - normaler Abzug (AC6)`() {
+    fun `test applyUpkeep - normaler Abzug`() {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
@@ -293,7 +293,7 @@ class GameServiceTest {
     }
 
     @Test
-    fun `test applyUpkeep - Grenzfall exakt 0 (AC6)`() {
+    fun `test applyUpkeep - Grenzfall exakt 0`() {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
@@ -315,7 +315,7 @@ class GameServiceTest {
     }
 
     @Test
-    fun `test applyUpkeep - Insolvenz mit Unit-Verlust (AC6)`() {
+    fun `test applyUpkeep - Insolvenz mit Unit-Verlust`() {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
@@ -332,13 +332,19 @@ class GameServiceTest {
         gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, 1, 1))
 
         val alice = state.players.first { it.name == "Alice" }
-        // Alice geht bankrott: Gold = 0, alle Einheiten gnadenlos gelöscht
+
+        // Alice geht bankrott: Gold = 0
         assertThat(alice.gold).isEqualTo(0)
-        assertThat(state.units.count { it.player == "Alice" }).isEqualTo(0)
+
+        // Die Einheiten sind noch da (3 Stück)
+        val aliceUnits = state.units.filter { it.player == "Alice" }
+        assertThat(aliceUnits.size).isEqualTo(3)
+        // aber sie sind alle zu Skeletten geworden
+        assertThat(aliceUnits.all { it.type == UnitType.SKELETON }).isTrue()
     }
 
     @Test
-    fun `test applyUpkeep - Insolvenz loest Win-Condition aus (AC6)`() {
+    fun `test applyUpkeep - Insolvenz loest Win-Condition aus`() {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")


### PR DESCRIPTION
**Problem / Zweck**

Das Wirtschaftssystem benötigt eine Mechanik, die Spieler dazu zwingt, ihre Truppengröße strategisch zu planen. Jede Einheit kostet pro Runde Unterhalt. Kann ein Spieler diesen nicht bezahlen, droht der wirtschaftliche Ruin (Insolvenz) und der Verlust der Armee.

**Lösung**
- Die Funktion `applyUpkeep(state)` wurde im `GameService` implementiert.
- Der Unterhalt wird via arithmetischer Reihe berechnet (`sumOf { 3 + it }`).
- Die Funktion wird in `switchTurn()` nach einer vollständigen Runde (wenn wieder Spieler 1 dran ist) aufgerufen.
- Bei Insolvenz (`gold < upkeep`) wird das Gold auf 0 gesetzt und alle Truppen des Spielers werden zu Skeleten (`UnitType.SKELETON`).
- Durch den anschließenden Aufruf von `checkWinCondition(state)` triggert eine Insolvenz automatisch das Spielende, da Skelette von der Win-Condition ignoriert werden und das Spiel somit erkennt, dass der insolvente Spieler 0 lebende Einheiten hat.
- Alte Tests wurden angepasst (Startgold für die Tests erhöht), da die neue Unterhaltsmechanik sonst zu vorzeitigen Timeouts/Draws geführt hat.

Closes #73 