### PR TITLE
Feat/57 win condition win condition base

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -103,6 +103,19 @@ class GameService(
         }
 
         if (enemyOnTarget != null) {
+            // Basis-Angriff: Basen sind nicht combat-faehig - sie werden ohne
+            // Stein-Schere-Papier-Resolution direkt zerstoert. Der Angreifer
+            // ueberlebt immer und zieht auf die Basis-Position.
+            // checkWinCondition triggert anschliessend den Sieg.
+            if (enemyOnTarget.type == UnitType.BASE) {
+                state.units.remove(enemyOnTarget)
+                unit.x = move.toX
+                unit.y = move.toY
+                switchTurn(state)
+                checkWinCondition(state)
+                return state
+            }
+
             val result = combatService.resolveCombat(unit, enemyOnTarget)
             combatService.applyCombatResult(result, unit, enemyOnTarget)
             if (!result.defenderSurvived) state.units.remove(enemyOnTarget)

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -125,23 +125,29 @@ class GameService(
     /**
      * Checks whether the match has ended after the latest mutation.
      *
-     * If exactly one player still has at least one non-SKELETON unit on the
-     * board, that player is declared the winner. If no player has any units
-     * left (e.g. last move was a mutual-kill combat), the match ends as a
-     * draw. Otherwise the game continues.
+     * Win condition is based on BASE existence:
+     * - If exactly one player still has a BASE on the board, that player
+     *   is declared the winner.
+     * - If no player has a BASE left (e.g. both bases were destroyed in
+     *   the same sequence of events), the match ends as a draw.
+     * - Otherwise the game continues.
      *
-     * Only runs while the game is IN_PROGRESS, so calling it from non-success
-     * paths or before game start is harmless.
+     * Regular unit losses (ARCHER/INFANTRY/CAVALRY) no longer end the
+     * match - players can lose all their regular units and the game
+     * continues as long as their base stands.
+     *
+     * Only runs while the game is IN_PROGRESS, so calling it from
+     * non-success paths or before game start is harmless.
      */
     private fun checkWinCondition(state: GameState) {
         if (state.status != GameStatus.IN_PROGRESS) return
 
-        val playersWithLivingUnits = state.units
-            .filter { it.type != UnitType.SKELETON }
+        val playersWithBase = state.units
+            .filter { it.type == UnitType.BASE }
             .map { it.player }
             .distinct()
 
-        when (playersWithLivingUnits.size) {
+        when (playersWithBase.size) {
             0 -> {
                 state.status = GameStatus.FINISHED
                 state.winner = null
@@ -149,11 +155,11 @@ class GameService(
             }
             1 -> {
                 state.status = GameStatus.FINISHED
-                state.winner = playersWithLivingUnits[0]
+                state.winner = playersWithBase[0]
                 state.currentTurn = null
             }
             else -> {
-                // >= 2 players still have units: game continues.
+                // >= 2 players still have a base: game continues.
             }
         }
     }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -165,48 +165,21 @@ class GameServiceTest {
     }
 
     @Test
-    fun `winner is set when last opponent unit dies after move`() {
+    fun `match ends as draw when both bases are destroyed simultaneously`() {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
 
+        // Beide Basen kuenstlich entfernen, danach normaler Move ausfuehren -
+        // checkWinCondition muss 0 Basen erkennen und Draw setzen.
         val state = gameService.getCurrentState()
-        // Bob behält nur seine CAVALRY (auf der Startposition); ARCHER und INFANTRY entfernen
-        state.units.removeIf { it.player == "Bob" && it.type != UnitType.CAVALRY }
+        state.units.removeIf { it.type == UnitType.BASE }
 
-        val aliceInfantry = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
-        val bobCavalry    = state.units.first { it.player == "Bob"   && it.type == UnitType.CAVALRY  }
-
-        // INFANTRY beats CAVALRY → Bob hat danach 0 Units, Alice gewinnt
+        val aliceArcher = state.units.first { it.player == "Alice" && it.type == UnitType.ARCHER }
         gameService.handleMove(Move(
-            player = "Alice", type = UnitType.INFANTRY,
-            fromX = aliceInfantry.x, fromY = aliceInfantry.y,
-            toX = bobCavalry.x, toY = bobCavalry.y
-        ))
-
-        val updated = gameService.getCurrentState()
-        assertThat(updated.status).isEqualTo(GameStatus.FINISHED)
-        assertThat(updated.winner).isEqualTo("Alice")
-        assertThat(updated.currentTurn).isNull()
-    }
-
-    @Test
-    fun `match ends as draw when last move kills both combatants`() {
-        gameService.initializeGame()
-        gameService.handleJoin("Alice")
-        gameService.handleJoin("Bob")
-
-        val state = gameService.getCurrentState()
-        // Beide Spieler haben nur noch je eine INFANTRY → gleicher Typ ⇒ beide sterben im Combat
-        state.units.removeIf { it.type != UnitType.INFANTRY }
-
-        val aliceInf = state.units.first { it.player == "Alice" }
-        val bobInf   = state.units.first { it.player == "Bob" }
-
-        gameService.handleMove(Move(
-            player = "Alice", type = UnitType.INFANTRY,
-            fromX = aliceInf.x, fromY = aliceInf.y,
-            toX = bobInf.x, toY = bobInf.y
+            player = "Alice", type = UnitType.ARCHER,
+            fromX = aliceArcher.x, fromY = aliceArcher.y,
+            toX = 0, toY = 0
         ))
 
         val updated = gameService.getCurrentState()
@@ -216,7 +189,7 @@ class GameServiceTest {
     }
 
     @Test
-    fun `match continues when opponent still has other units after combat`() {
+    fun `match continues when both bases still stand after combat`() {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
@@ -225,7 +198,7 @@ class GameServiceTest {
         val aliceInfantry = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
         val bobCavalry    = state.units.first { it.player == "Bob"   && it.type == UnitType.CAVALRY  }
 
-        // INFANTRY beats CAVALRY: Bob verliert CAVALRY, hat aber noch ARCHER + INFANTRY
+        // INFANTRY beats CAVALRY: Bob verliert CAVALRY, beide Basen stehen weiterhin
         gameService.handleMove(Move(
             player = "Alice", type = UnitType.INFANTRY,
             fromX = aliceInfantry.x, fromY = aliceInfantry.y,

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -301,4 +301,83 @@ class GameServiceTest {
         }
     }
 
+    @Test
+    fun `winner is set when attacker reaches opponent base`() {
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+
+        val state = gameService.getCurrentState()
+        val aliceInfantry = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
+        val bobBase       = state.units.first { it.player == "Bob"   && it.type == UnitType.BASE }
+
+        // Alice zieht ihre INFANTRY direkt auf Bob's Basis-Hex - das beendet
+        // das Spiel sofort, unabhaengig vom Stein-Schere-Papier-System.
+        gameService.handleMove(Move(
+            player = "Alice", type = UnitType.INFANTRY,
+            fromX = aliceInfantry.x, fromY = aliceInfantry.y,
+            toX = bobBase.x, toY = bobBase.y
+        ))
+
+        val updated = gameService.getCurrentState()
+        assertThat(updated.status).isEqualTo(GameStatus.FINISHED)
+        assertThat(updated.winner).isEqualTo("Alice")
+        assertThat(updated.currentTurn).isNull()
+
+        // Bob's Basis ist entfernt
+        assertThat(updated.units.any { it.player == "Bob" && it.type == UnitType.BASE }).isFalse()
+
+        // Alice's INFANTRY steht jetzt auf der ehemaligen Basis-Position
+        val aliceAfter = updated.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
+        assertThat(aliceAfter.x).isEqualTo(bobBase.x)
+        assertThat(aliceAfter.y).isEqualTo(bobBase.y)
+    }
+
+    @Test
+    fun `regular unit killed by combat does NOT end the match`() {
+        // Stellt sicher, dass die alte "alle Units tot = Sieg"-Regel nicht
+        // mehr greift. Nur Basis-Zerstoerung darf das Spiel beenden.
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+
+        val state = gameService.getCurrentState()
+
+        // Reduziere Alice's regulaere Units auf nur die INFANTRY,
+        // ihre Basis bleibt aber stehen.
+        state.units.removeIf {
+            it.player == "Alice" &&
+                it.type != UnitType.INFANTRY &&
+                it.type != UnitType.BASE
+        }
+        // Auch Bob's Units reduzieren - er greift mit CAVALRY an
+        state.units.removeIf {
+            it.player == "Bob" &&
+                it.type != UnitType.CAVALRY &&
+                it.type != UnitType.BASE
+        }
+
+        val aliceInfantry = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
+        val bobCavalry    = state.units.first { it.player == "Bob"   && it.type == UnitType.CAVALRY }
+
+        // Alice greift Bob's CAVALRY an. INFANTRY beats CAVALRY,
+        // Bob verliert seine einzige regulaere Unit - hat aber noch Basis.
+        gameService.handleMove(Move(
+            player = "Alice", type = UnitType.INFANTRY,
+            fromX = aliceInfantry.x, fromY = aliceInfantry.y,
+            toX = bobCavalry.x, toY = bobCavalry.y
+        ))
+
+        val updated = gameService.getCurrentState()
+        assertThat(updated.status).isEqualTo(GameStatus.IN_PROGRESS)
+        assertThat(updated.winner).isNull()
+
+        // Bob hat keine regulaeren Units mehr, aber seine Basis steht noch
+        val bobRegularUnits = updated.units.filter {
+            it.player == "Bob" && it.type != UnitType.BASE
+        }
+        assertThat(bobRegularUnits).isEmpty()
+        assertThat(updated.units.any { it.player == "Bob" && it.type == UnitType.BASE }).isTrue
+    }
+
 }


### PR DESCRIPTION
Stellt die Win-Condition von der alten Regel ("alle gegnerischen
Truppen tot") auf die neue Regel ("gegnerische Basis zerstört") um.
Setzt damit die Spielregel-Änderung aus dem Team-Meeting in Code.