### PR TITLE
Feature/issue 80 room registry

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/RoomRegistry.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/RoomRegistry.kt
@@ -76,17 +76,11 @@ class RoomRegistry {
 
     /**
      * Generates a unique 6-character alphanumeric join code.
-     * Retries up to 10 times to ensure uniqueness.
      *
      * @return A unique 6-character join code.
-     * @throws IllegalStateException if no unique code could be generated after 10 attempts.
      */
     private fun generateJoinCode(): String {
         val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-        repeat(10) {
-            val code = (1..6).map { chars.random() }.joinToString("")
-            if (rooms.none { it.value.joinCode == code }) return code
-        }
-        throw IllegalStateException("Could not generate unique join code after 10 attempts")
+        return (1..6).map { chars.random() }.joinToString("")
     }
 }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/RoomRegistry.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/RoomRegistry.kt
@@ -1,0 +1,90 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * Registry that manages all active game rooms on the server.
+ * Supports concurrent access for parallel game sessions.
+ */
+@Component
+class RoomRegistry {
+
+    private val rooms = mutableMapOf<String, Room>()
+    private val lock = Any()
+
+    /**
+     * Creates a new room with a unique roomId and joinCode.
+     *
+     * @param mode The game mode for the new room.
+     * @return The newly created room.
+     */
+    fun createRoom(mode: GameMode): Room = synchronized(lock) {
+        val roomId = UUID.randomUUID().toString()
+        val joinCode = generateJoinCode()
+        val room = Room(roomId, joinCode, mode)
+        rooms[roomId] = room
+        return room
+    }
+
+    /**
+     * Returns all rooms that are currently waiting for players.
+     *
+     * @return List of open rooms.
+     */
+    fun getOpenRooms(): List<Room> = synchronized(lock) {
+        return rooms.values.filter { it.status == GameStatus.WAITING_FOR_PLAYERS }
+    }
+
+    /**
+     * Finds a room by its unique roomId.
+     *
+     * @param roomId The unique identifier of the room.
+     * @return The room if found, null otherwise.
+     */
+    fun findById(roomId: String): Room? = synchronized(lock) {
+        return rooms[roomId]
+    }
+
+    /**
+     * Finds a room by its join code.
+     *
+     * @param joinCode The 6-character join code.
+     * @return The room if found, null otherwise.
+     */
+    fun findByJoinCode(joinCode: String): Room? = synchronized(lock) {
+        return rooms.values.find { it.joinCode == joinCode }
+    }
+
+    /**
+     * Removes a room from the registry.
+     *
+     * @param roomId The unique identifier of the room to remove.
+     */
+    fun removeRoom(roomId: String) = synchronized(lock) {
+        rooms.remove(roomId)
+    }
+
+    /**
+     * Returns all rooms regardless of status.
+     *
+     * @return List of all rooms.
+     */
+    fun getAllRooms(): List<Room> = synchronized(lock) {
+        return rooms.values.toList()
+    }
+
+    /**
+     * Generates a random 6-character alphanumeric join code.
+     *
+     * @return A 6-character join code.
+     */
+    private fun generateJoinCode(): String {
+        val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        var code: String
+        do {
+            code = (1..6).map { chars.random() }.joinToString("")
+        } while (rooms.values.any { it.joinCode == code })
+        return code
+    }
+}

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/RoomRegistry.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/RoomRegistry.kt
@@ -2,16 +2,16 @@ package at.aau.hexabrawl.websocketserver.model
 
 import org.springframework.stereotype.Component
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Registry that manages all active game rooms on the server.
- * Supports concurrent access for parallel game sessions.
+ * Uses ConcurrentHashMap for thread-safe parallel access without explicit locking.
  */
 @Component
 class RoomRegistry {
 
-    private val rooms = mutableMapOf<String, Room>()
-    private val lock = Any()
+    private val rooms = ConcurrentHashMap<String, Room>()
 
     /**
      * Creates a new room with a unique roomId and joinCode.
@@ -19,7 +19,7 @@ class RoomRegistry {
      * @param mode The game mode for the new room.
      * @return The newly created room.
      */
-    fun createRoom(mode: GameMode): Room = synchronized(lock) {
+    fun createRoom(mode: GameMode): Room {
         val roomId = UUID.randomUUID().toString()
         val joinCode = generateJoinCode()
         val room = Room(roomId, joinCode, mode)
@@ -32,7 +32,7 @@ class RoomRegistry {
      *
      * @return List of open rooms.
      */
-    fun getOpenRooms(): List<Room> = synchronized(lock) {
+    fun getOpenRooms(): List<Room> {
         return rooms.values.filter { it.status == GameStatus.WAITING_FOR_PLAYERS }
     }
 
@@ -42,7 +42,7 @@ class RoomRegistry {
      * @param roomId The unique identifier of the room.
      * @return The room if found, null otherwise.
      */
-    fun findById(roomId: String): Room? = synchronized(lock) {
+    fun findById(roomId: String): Room? {
         return rooms[roomId]
     }
 
@@ -52,7 +52,7 @@ class RoomRegistry {
      * @param joinCode The 6-character join code.
      * @return The room if found, null otherwise.
      */
-    fun findByJoinCode(joinCode: String): Room? = synchronized(lock) {
+    fun findByJoinCode(joinCode: String): Room? {
         return rooms.values.find { it.joinCode == joinCode }
     }
 
@@ -61,7 +61,7 @@ class RoomRegistry {
      *
      * @param roomId The unique identifier of the room to remove.
      */
-    fun removeRoom(roomId: String) = synchronized(lock) {
+    fun removeRoom(roomId: String) {
         rooms.remove(roomId)
     }
 
@@ -70,21 +70,23 @@ class RoomRegistry {
      *
      * @return List of all rooms.
      */
-    fun getAllRooms(): List<Room> = synchronized(lock) {
+    fun getAllRooms(): List<Room> {
         return rooms.values.toList()
     }
 
     /**
-     * Generates a random 6-character alphanumeric join code.
+     * Generates a unique 6-character alphanumeric join code.
+     * Retries up to 10 times to ensure uniqueness.
      *
-     * @return A 6-character join code.
+     * @return A unique 6-character join code.
+     * @throws IllegalStateException if no unique code could be generated after 10 attempts.
      */
     private fun generateJoinCode(): String {
         val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-        var code: String
-        do {
-            code = (1..6).map { chars.random() }.joinToString("")
-        } while (rooms.values.any { it.joinCode == code })
-        return code
+        repeat(10) {
+            val code = (1..6).map { chars.random() }.joinToString("")
+            if (rooms.none { it.value.joinCode == code }) return code
+        }
+        throw IllegalStateException("Could not generate unique join code after 10 attempts")
     }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomRegistryTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomRegistryTest.kt
@@ -129,4 +129,18 @@ class RoomRegistryTest {
         assertEquals(listOf("Alice"), room.players)
     }
 
+    @Test
+    fun `findByJoinCode returns null when registry is empty`() {
+        val result = registry.findByJoinCode("AAAAAA")
+        assertNull(result)
+    }
+
+    @Test
+    fun `findByJoinCode returns null when room exists but code does not match`() {
+        registry.createRoom(GameMode.DUAL_VALLEY) // Raum existiert
+        assertNull(registry.findByJoinCode("ZZZZZZ")) // aber falscher Code
+    }
+
+
+
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomRegistryTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomRegistryTest.kt
@@ -1,0 +1,132 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class RoomRegistryTest {
+
+    private lateinit var registry: RoomRegistry
+
+    @BeforeEach
+    fun setUp() {
+        registry = RoomRegistry()
+    }
+
+    @Test
+    fun `createRoom returns room with correct mode`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+        assertEquals(GameMode.DUAL_VALLEY, room.mode)
+    }
+
+    @Test
+    fun `createRoom generates unique roomIds`() {
+        val room1 = registry.createRoom(GameMode.DUAL_VALLEY)
+        val room2 = registry.createRoom(GameMode.DUAL_VALLEY)
+        assertNotEquals(room1.roomId, room2.roomId)
+    }
+
+    @Test
+    fun `createRoom generates 6 character joinCode`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+        assertEquals(6, room.joinCode.length)
+    }
+
+    @Test
+    fun `createRoom adds room to registry`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+        assertNotNull(registry.findById(room.roomId))
+    }
+
+
+    @Test
+    fun `getOpenRooms returns only WAITING_FOR_PLAYERS rooms`() {
+        val room1 = registry.createRoom(GameMode.DUAL_VALLEY)
+        val room2 = registry.createRoom(GameMode.DUAL_VALLEY)
+        room2.gameState.status = GameStatus.IN_PROGRESS
+
+        val openRooms = registry.getOpenRooms()
+        assertTrue(openRooms.contains(room1))
+        assertFalse(openRooms.contains(room2))
+    }
+
+    @Test
+    fun `getOpenRooms returns empty list when no open rooms`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+        room.gameState.status = GameStatus.FINISHED
+        assertTrue(registry.getOpenRooms().isEmpty())
+    }
+
+    @Test
+    fun `findById returns correct room`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+        assertEquals(room, registry.findById(room.roomId))
+    }
+
+    @Test
+    fun `findById returns null for unknown roomId`() {
+        assertNull(registry.findById("unknown-id"))
+    }
+
+    @Test
+    fun `findByJoinCode returns correct room`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+        assertEquals(room, registry.findByJoinCode(room.joinCode))
+    }
+
+    @Test
+    fun `findByJoinCode returns null for unknown joinCode`() {
+        assertNull(registry.findByJoinCode("XXXXXX"))
+    }
+
+    @Test
+    fun `removeRoom removes room from registry`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+        registry.removeRoom(room.roomId)
+        assertNull(registry.findById(room.roomId))
+    }
+
+    @Test
+    fun `getAllRooms returns all rooms`() {
+        registry.createRoom(GameMode.DUAL_VALLEY)
+        registry.createRoom(GameMode.TRIAD_OUTPOST)
+        registry.createRoom(GameMode.BATTLEFIELD_PEAKS)
+        assertEquals(3, registry.getAllRooms().size)
+    }
+
+    @Test
+    fun `getAllRooms returns empty list when no rooms`() {
+        assertTrue(registry.getAllRooms().isEmpty())
+    }
+
+    @Test
+    fun `registry supports 40 parallel rooms`() {
+        repeat(40) { registry.createRoom(GameMode.DUAL_VALLEY) }
+        assertEquals(40, registry.getAllRooms().size)
+    }
+
+    @Test
+    fun `createRoom works for all game modes`() {
+        val dual = registry.createRoom(GameMode.DUAL_VALLEY)
+        val triad = registry.createRoom(GameMode.TRIAD_OUTPOST)
+        val battle = registry.createRoom(GameMode.BATTLEFIELD_PEAKS)
+
+        assertEquals(GameMode.DUAL_VALLEY, dual.mode)
+        assertEquals(GameMode.TRIAD_OUTPOST, triad.mode)
+        assertEquals(GameMode.BATTLEFIELD_PEAKS, battle.mode)
+    }
+
+    @Test
+    fun `room maxPlayers matches game mode`() {
+        val room = registry.createRoom(GameMode.TRIAD_OUTPOST)
+        assertEquals(3, room.maxPlayers)
+    }
+
+    @Test
+    fun `room players list reflects game state`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+        room.gameState.players.add(Player("Alice", "s1", PlayerColor.RED))
+        assertEquals(listOf("Alice"), room.players)
+    }
+
+}


### PR DESCRIPTION
Closes #80

## Änderungen
- `RoomRegistry` mit `ConcurrentHashMap` für thread-safe parallelen Zugriff
- Räume werden mit eindeutiger UUID als roomId erstellt
- 6-stelliger alphanumerischer joinCode wird generiert 
- Alle CRUD Operationen implementiert: createRoom, findById, findByJoinCode, removeRoom, getAllRooms, getOpenRooms
- KDocs für alle Methoden vorhanden
- 17 Unit Tests vorhanden

## Details
Sub-Issue von #51 — Multisession Management