### PR TITLE
Feat #108: Farm-Logik und Einkommen implementieren

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -247,7 +247,8 @@ class GameService(
 
     private fun applyUpkeep(state: GameState) {
         state.players.forEach { player ->
-            val playerUnits = state.units.filter { it.player == player.name }
+            // Skelette herausfiltern, damit sie in Zukunft keinen Unterhalt mehr kosten
+            val playerUnits = state.units.filter { it.player == player.name && it.type != UnitType.SKELETON }
             val unitCount = playerUnits.size
 
             // Unterhalt berechnen (Arithmetische Reihe: 1. Einheit kostet 3, jede weitere +1)
@@ -257,12 +258,13 @@ class GameService(
                 // Normaler Abzug
                 player.gold -= upkeep
             } else {
-                // Insolvenz: alle Truppen werden restlos entfernt
+                // Insolvenz: Gold auf 0, alle lebenden Truppen werden zu Skeletten!
                 player.gold = 0
-                state.units.removeAll(playerUnits.toSet())
+                playerUnits.forEach { it.type = UnitType.SKELETON }
             }
         }
-        // Prüfen, ob durch Insolvenz ein Spieler alle Einheiten verloren hat (Win-Condition)
+
+        // Prüfen, ob durch Insolvenz ein Spieler alle lebenden Einheiten verloren hat (Win-Condition)
         checkWinCondition(state)
     }
 }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -12,6 +12,9 @@ class GameService(
     companion object {
         const val MAX_PLAYERS = 2
         const val STARTING_GOLD = 6
+        const val FARM_INCOME_PER_ROUND = 3
+        const val FARM_BASE_COST = 12
+        const val FARM_COST_INCREMENT = 2
     }
 
     fun handleJoin(state: GameState, playerName: String, sessionId:String=""): GameState = synchronized(state.lock) {
@@ -247,6 +250,9 @@ class GameService(
 
     private fun applyUpkeep(state: GameState) {
         state.players.forEach { player ->
+            // Farm-Einkommen gutschreiben
+            player.gold += player.farms * FARM_INCOME_PER_ROUND
+
             // Skelette herausfiltern, damit sie in Zukunft keinen Unterhalt mehr kosten
             val playerUnits = state.units.filter { it.player == player.name && it.type != UnitType.SKELETON }
             val unitCount = playerUnits.size
@@ -266,5 +272,22 @@ class GameService(
 
         // Prüfen, ob durch Insolvenz ein Spieler alle lebenden Einheiten verloren hat (Win-Condition)
         checkWinCondition(state)
+    }
+
+    fun buyFarm(state: GameState, playerName: String): GameState = synchronized(state.lock) {
+        if (state.status != GameStatus.IN_PROGRESS) return state
+
+        val player = state.players.find { it.name == playerName } ?: return state
+
+        val cost = FARM_BASE_COST + (player.farms * FARM_COST_INCREMENT)
+
+        if (player.gold >= cost) {
+            player.gold -= cost
+            player.farms += 1
+            println("Service: $playerName kaufte Farm für $cost. (Total: ${player.farms})")
+        } else {
+            println("Service: $playerName hat zu wenig Gold ($cost) für Farm.")
+        }
+        return state
     }
 }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -11,7 +11,7 @@ class GameService(
 
     companion object {
         const val MAX_PLAYERS = 2
-        const val STARTING_GOLD = 10
+        const val STARTING_GOLD = 6
     }
 
     fun handleJoin(state: GameState, playerName: String, sessionId:String=""): GameState = synchronized(state.lock) {

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -99,8 +99,7 @@ class GameService(
         unit.x = move.toX
         unit.y = move.toY
 
-        val (p1, p2) = state.players
-        state.currentTurn = if (state.currentTurn == p1.name) p2.name else p1.name
+        switchTurn(state)
 
         checkWinCondition(state)
         return state
@@ -157,6 +156,11 @@ class GameService(
                 p2.name
             else
                 p1.name
+
+        // Wenn der Zug wieder bei Spieler 1 (p1) ist, ist eine Runde vorbei
+        if (state.currentTurn == p1.name) {
+            applyUpkeep(state)
+        }
     }
 
     // WICHTIG FÜR TEST  Nur den aktuellen Stand lesen
@@ -241,4 +245,24 @@ class GameService(
         sessionId: String
     ): GameState = handleDisconnect(this.gameState, sessionId)
 
+    private fun applyUpkeep(state: GameState) {
+        state.players.forEach { player ->
+            val playerUnits = state.units.filter { it.player == player.name }
+            val unitCount = playerUnits.size
+
+            // Unterhalt berechnen (Arithmetische Reihe: 1. Einheit kostet 3, jede weitere +1)
+            val upkeep = (0 until unitCount).sumOf { 3 + it }
+
+            if (player.gold >= upkeep) {
+                // Normaler Abzug
+                player.gold -= upkeep
+            } else {
+                // Insolvenz: alle Truppen werden restlos entfernt
+                player.gold = 0
+                state.units.removeAll(playerUnits.toSet())
+            }
+        }
+        // Prüfen, ob durch Insolvenz ein Spieler alle Einheiten verloren hat (Win-Condition)
+        checkWinCondition(state)
+    }
 }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -11,6 +11,7 @@ class GameService(
 
     companion object {
         const val MAX_PLAYERS = 2
+        const val STARTING_GOLD = 10
     }
 
     fun handleJoin(state: GameState, playerName: String, sessionId:String=""): GameState = synchronized(state.lock) {
@@ -18,7 +19,7 @@ class GameService(
 
         if (!state.players.any{it.name == playerName} && state.players.size < MAX_PLAYERS) {
             val color = if (state.players.isEmpty()) PlayerColor.RED else PlayerColor.BLUE
-            state.players.add(Player(playerName, sessionId,color))
+            state.players.add(Player(playerName, sessionId,color, STARTING_GOLD))
             println("JOIN: $playerName")
         }
 

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Player.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Player.kt
@@ -5,5 +5,6 @@ data class Player (
     val name : String = "",
     val sessionId : String = "",
     val color: PlayerColor = PlayerColor.RED,
-    var gold: Int = 0
+    var gold: Int = 0,
+    var farms: Int = 0
 ){}

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Player.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Player.kt
@@ -4,6 +4,6 @@ package at.aau.hexabrawl.websocketserver.model
 data class Player (
     val name : String = "",
     val sessionId : String = "",
-    val color: PlayerColor = PlayerColor.RED
-
+    val color: PlayerColor = PlayerColor.RED,
+    var gold: Int = 0
 ){}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -139,6 +139,9 @@ class WebSocketBrokerControllerTest {
         controller.handleJoin("Alice", "session-1")
         controller.handleJoin("Bob", "session-2")
 
+        // Gold geben, damit sie nach der Runde nicht pleitegehen
+        gameService.getCurrentState().players.forEach { it.gold = 100 }
+
         // First move
         controller.handleMove(
             Move("Alice", UnitType.INFANTRY, 3, 2, 3, 3)
@@ -212,6 +215,9 @@ class WebSocketBrokerControllerTest {
     fun `turn switches after valid move`() {
         controller.handleJoin("Alice", "session-1")
         controller.handleJoin("Bob", "session-2")
+
+        // Gold geben, damit sie nach der Runde nicht pleitegehen
+        gameService.getCurrentState().players.forEach { it.gold = 100 }
 
         // Alice move
         val state1 = controller.handleMove(

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -364,4 +364,63 @@ class GameServiceTest {
         assertThat(state.status).isEqualTo(GameStatus.FINISHED)
         assertThat(state.winner).isEqualTo("Bob")
     }
+
+    @Test
+    fun `test buyFarm - erfolgreicher Kauf erhoeht die Kosten fuer die naechste Farm`() {
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+
+        val state = gameService.getCurrentState()
+        val alice = state.players.first { it.name == "Alice" }
+
+        alice.gold = 30
+
+        gameService.buyFarm(state, "Alice")
+        assertThat(alice.farms).isEqualTo(1)
+        assertThat(alice.gold).isEqualTo(18)
+
+        gameService.buyFarm(state, "Alice")
+        assertThat(alice.farms).isEqualTo(2)
+        assertThat(alice.gold).isEqualTo(4)
+    }
+
+    @Test
+    fun `test buyFarm - schlaegt bei zu wenig Gold fehl`() {
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+
+        val state = gameService.getCurrentState()
+        val alice = state.players.first { it.name == "Alice" }
+
+        alice.gold = 10
+        gameService.buyFarm(state, "Alice")
+
+        assertThat(alice.farms).isEqualTo(0)
+        assertThat(alice.gold).isEqualTo(10)
+    }
+
+    @Test
+    fun `test applyUpkeep - Farm-Einkommen verhindert Insolvenz`() {
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+        val state = gameService.getCurrentState()
+        val alice = state.players.first { it.name == "Alice" }
+        val bob = state.players.first { it.name == "Bob" }
+
+        alice.farms = 1
+        alice.gold = 9
+        bob.gold = 20
+
+        val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY, aliceInf.x, aliceInf.y, 0, 0))
+        val bobInf = state.units.first { it.player == "Bob" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, 1, 1))
+
+        assertThat(alice.gold).isEqualTo(0)
+        assertThat(alice.farms).isEqualTo(1)
+        assertThat(state.units.filter { it.player == "Alice" }.all { it.type != UnitType.SKELETON }).isTrue()
+    }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -268,4 +268,94 @@ class GameServiceTest {
 
         assertThat(player.gold).isEqualTo(GameService.STARTING_GOLD)
     }
+
+    @Test
+    fun `test applyUpkeep - normaler Abzug (AC6)`() {
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+
+        val state = gameService.getCurrentState()
+        // Beide Spieler bekommen genug Gold
+        state.players.forEach { it.gold = 20 }
+
+        // Zug Alice
+        val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY, aliceInf.x, aliceInf.y, 0, 0))
+
+        // Zug Bob -> Beendet die Runde, applyUpkeep wird getriggert
+        val bobInf = state.units.first { it.player == "Bob" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, 1, 1))
+
+        // Bei 3 Start-Einheiten kostet der Unterhalt 12 Gold (3+4+5). 20 - 12 = 8.
+        assertThat(state.players.first { it.name == "Alice" }.gold).isEqualTo(8)
+        assertThat(state.players.first { it.name == "Bob" }.gold).isEqualTo(8)
+    }
+
+    @Test
+    fun `test applyUpkeep - Grenzfall exakt 0 (AC6)`() {
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+
+        val state = gameService.getCurrentState()
+        // Spieler bekommen exakt das Gold für den Unterhalt von 3 Einheiten
+        state.players.forEach { it.gold = 12 }
+
+        val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY, aliceInf.x, aliceInf.y, 0, 0))
+
+        val bobInf = state.units.first { it.player == "Bob" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, 1, 1))
+
+        val alice = state.players.first { it.name == "Alice" }
+        // Gold muss genau auf 0 fallen, aber die Einheiten müssen bleiben
+        assertThat(alice.gold).isEqualTo(0)
+        assertThat(state.units.count { it.player == "Alice" }).isEqualTo(3)
+    }
+
+    @Test
+    fun `test applyUpkeep - Insolvenz mit Unit-Verlust (AC6)`() {
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+
+        val state = gameService.getCurrentState()
+        // Alice hat 1 Gold zu wenig. Bob hat genug.
+        state.players.first { it.name == "Alice" }.gold = 11
+        state.players.first { it.name == "Bob" }.gold = 20
+
+        val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY, aliceInf.x, aliceInf.y, 0, 0))
+
+        val bobInf = state.units.first { it.player == "Bob" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, 1, 1))
+
+        val alice = state.players.first { it.name == "Alice" }
+        // Alice geht bankrott: Gold = 0, alle Einheiten gnadenlos gelöscht
+        assertThat(alice.gold).isEqualTo(0)
+        assertThat(state.units.count { it.player == "Alice" }).isEqualTo(0)
+    }
+
+    @Test
+    fun `test applyUpkeep - Insolvenz loest Win-Condition aus (AC6)`() {
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+
+        val state = gameService.getCurrentState()
+        // Alice hat zu wenig Geld und geht pleite
+        state.players.first { it.name == "Alice" }.gold = 5
+        state.players.first { it.name == "Bob" }.gold = 20
+
+        val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY, aliceInf.x, aliceInf.y, 0, 0))
+
+        val bobInf = state.units.first { it.player == "Bob" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, 1, 1))
+
+        // Da Alice durch Insolvenz 0 Einheiten hat, muss Bob sofort gewinnen
+        assertThat(state.status).isEqualTo(GameStatus.FINISHED)
+        assertThat(state.winner).isEqualTo("Bob")
+    }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -17,7 +17,7 @@ class GameServiceTest {
         // 1. Erster Join
         gameService.handleJoin("Alice")
         val stateAfterAlice = gameService.getCurrentState()
-        assertThat(stateAfterAlice.players).containsExactly(Player("Alice"))
+        assertThat(stateAfterAlice.players).containsExactly(Player("Alice", gold = GameService.STARTING_GOLD))
 
         // 2. Doppelter Join (Alice versucht nochmal) -> Darf nichts ändern
         gameService.handleJoin("Alice")
@@ -260,4 +260,12 @@ class GameServiceTest {
         assertThat(updated.currentTurn).isEqualTo("Bob")
     }
 
+    @Test
+    fun `player receives starting gold on join`() {
+        gameService.handleJoin("Alice")
+
+        val player = gameService.getCurrentState().players.first { it.name == "Alice" }
+
+        assertThat(player.gold).isEqualTo(GameService.STARTING_GOLD)
+    }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -270,7 +270,7 @@ class GameServiceTest {
     }
 
     @Test
-    fun `test applyUpkeep - normaler Abzug (AC6)`() {
+    fun `test applyUpkeep - normaler Abzug`() {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
@@ -293,7 +293,7 @@ class GameServiceTest {
     }
 
     @Test
-    fun `test applyUpkeep - Grenzfall exakt 0 (AC6)`() {
+    fun `test applyUpkeep - Grenzfall exakt 0`() {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
@@ -315,7 +315,7 @@ class GameServiceTest {
     }
 
     @Test
-    fun `test applyUpkeep - Insolvenz mit Unit-Verlust (AC6)`() {
+    fun `test applyUpkeep - Insolvenz mit Unit-Verlust`() {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
@@ -332,13 +332,19 @@ class GameServiceTest {
         gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, 1, 1))
 
         val alice = state.players.first { it.name == "Alice" }
-        // Alice geht bankrott: Gold = 0, alle Einheiten gnadenlos gelöscht
+
+        // Alice geht bankrott: Gold = 0
         assertThat(alice.gold).isEqualTo(0)
-        assertThat(state.units.count { it.player == "Alice" }).isEqualTo(0)
+
+        // Die Einheiten sind noch da (3 Stück)
+        val aliceUnits = state.units.filter { it.player == "Alice" }
+        assertThat(aliceUnits.size).isEqualTo(3)
+        // aber sie sind alle zu Skeletten geworden
+        assertThat(aliceUnits.all { it.type == UnitType.SKELETON }).isTrue()
     }
 
     @Test
-    fun `test applyUpkeep - Insolvenz loest Win-Condition aus (AC6)`() {
+    fun `test applyUpkeep - Insolvenz loest Win-Condition aus`() {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")


### PR DESCRIPTION
**Problem / Zweck**

Das Wirtschaftssystem benötigt eine Möglichkeit für Spieler, ihr Gold in langfristiges Einkommen zu investieren, um dem steigenden Truppen-Unterhalt entgegenzuwirken. Dafür müssen Farmen gekauft werden können, die pro Runde einen festen Goldbetrag generieren, wobei jede zusätzlich gekaufte Farm teurer in der Anschaffung wird.

**Lösung**

* Das Feld `farms` (Default: 0) wurde in der `Player` Data Class hinzugefügt.
* Die Konstanten für das System (`FARM_INCOME_PER_ROUND = 3`, `FARM_BASE_COST = 12`, `FARM_COST_INCREMENT = 2`) wurden im `GameService` deklariert.
* Die Funktion `buyFarm(state, playerName)` wurde im `GameService` implementiert. Sie prüft die Deckung, berechnet die dynamischen Kosten und wickelt den Kauf ab.
* Die Funktion `applyUpkeep(state)` wurde erweitert: Das Farm-Einkommen wird den Spielern nun zu Beginn der Methode gutgeschrieben, *bevor* der Unterhalt abgezogen oder eine Insolvenz geprüft wird.
* Es wurden 3 neue Tests in `GameServiceTest` geschrieben, die das Einkommen, den Kauf, die Preissteigerung und die Fehlerbehandlung bei zu wenig Gold absichern.

Closes #108