### PR TITLE
Feat #109: Farm-Endpoint und Error-Handling implementieren

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -100,7 +100,6 @@ class WebSocketBrokerController(
         val cost = GameService.FARM_BASE_COST + (player.farms * GameService.FARM_COST_INCREMENT)
 
         if (player.gold < cost) {
-            // Deine eigene Hilfsfunktion nutzen!
             sendError(sessionId, ErrorCode.INSUFFICIENT_GOLD, "Nicht genug Gold für eine Farm!")
             return null // null returned -> kein Broadcast an alle
         }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -87,6 +87,28 @@ class WebSocketBrokerController(
         return stateAfter
     }
 
+    @MessageMapping("/buyFarm")
+    @SendTo("/topic/game")
+    fun buyFarm(headerAccessor: SimpMessageHeaderAccessor): GameState? {
+        val sessionId = headerAccessor.sessionId ?: ""
+        val state = gameService.getCurrentState()
+
+        // Spieler über die SessionId suchen
+        val player = state.players.find { it.sessionId == sessionId } ?: return null
+
+        // Kosten prüfen
+        val cost = GameService.FARM_BASE_COST + (player.farms * GameService.FARM_COST_INCREMENT)
+
+        if (player.gold < cost) {
+            // Deine eigene Hilfsfunktion nutzen!
+            sendError(sessionId, ErrorCode.INSUFFICIENT_GOLD, "Nicht genug Gold für eine Farm!")
+            return null // null returned -> kein Broadcast an alle
+        }
+
+        // Kauf durchführen und den neuen GameState an /topic/game senden
+        return gameService.buyFarm(state, player.name)
+    }
+
 
     fun handleJoin(name: String, sessionId: String) = gameService.handleJoin(name, sessionId)
     fun handleMove(move: Move) = gameService.handleMove(move)

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/ErrorCode.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/ErrorCode.kt
@@ -4,5 +4,6 @@ enum class ErrorCode {
     NOT_YOUR_TURN,
     INVALID_MOVE,
     GAME_FULL,
-    GAME_NOT_STARTED
+    GAME_NOT_STARTED,
+    INSUFFICIENT_GOLD
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -362,4 +362,83 @@ class WebSocketBrokerControllerTest {
             argThat { it is ErrorMessage && it.errorCode == ErrorCode.INVALID_MOVE }
         )
     }
+
+    @Test
+    fun `buyFarm via websocket returns updated state when gold is sufficient`() {
+        controller.handleJoin("Alice", "test-session")
+        controller.handleJoin("Bob", "session-2")
+
+        val state = gameService.getCurrentState()
+        val alice = state.players.first { it.name == "Alice" }
+        alice.gold = 20 // Genug Gold
+
+        // Endpoint aufrufen
+        val result = controller.buyFarm(headerAccessor)
+
+        // Verifizieren, dass der Kauf klappt und der neue State zurückkommt (@SendTo greift)
+        assertNotNull(result)
+        assertEquals(1, result?.players?.first { it.name == "Alice" }?.farms)
+        assertEquals(8, result?.players?.first { it.name == "Alice" }?.gold)
+    }
+
+    @Test
+    fun `buyFarm via websocket sends INSUFFICIENT_GOLD error when poor`() {
+        controller.handleJoin("Alice", "test-session")
+        controller.handleJoin("Bob", "session-2")
+
+        val state = gameService.getCurrentState()
+        val alice = state.players.first { it.name == "Alice" }
+        alice.gold = 5 // Zu wenig Gold
+
+        // Endpoint aufrufen
+        val result = controller.buyFarm(headerAccessor)
+
+        // Verifizieren, dass kein State gebroadcastet wird...
+        assertNull(result)
+
+        // ... sondern stattdessen exakt der Error an den User geschickt wird
+        verify(messagingTemplate).convertAndSendToUser(
+            eq("test-session"),
+            eq("/queue/errors"),
+            argThat { it is ErrorMessage && it.errorCode == ErrorCode.INSUFFICIENT_GOLD }
+        )
+    }
+
+    @Test
+    fun `buyFarm returns null if player session is unknown`() {
+        // Leeres Spiel, niemand ist beigetreten -> headerAccessor hat test-session
+        val result = controller.buyFarm(headerAccessor)
+
+        // Da die Session unbekannt ist, muss der Controller direkt null zurückgeben
+        assertNull(result)
+    }
+
+    @Test
+    fun `buyFarm handles null sessionId from headerAccessor gracefully`() {
+        // Simuliert, dass das Netzwerk keine Session-ID mitschickt
+        val localHeaderAccessor = mock(SimpMessageHeaderAccessor::class.java)
+        `when`(localHeaderAccessor.sessionId).thenReturn(null)
+
+        val result = controller.buyFarm(localHeaderAccessor)
+
+        // Da die Session null (bzw. "") ist, wird kein Spieler gefunden -> null
+        assertNull(result)
+    }
+
+    @Test
+    fun `join allows reconnecting player even if game is max capacity`() {
+        // Spiel ist voll mit Alice und Bob
+        controller.handleJoin("Alice", "session-1")
+        controller.handleJoin("Bob", "session-2")
+
+        // Alice verliert die Verbindung und joint neu mit neuer Session-ID
+        val localHeaderAccessor = mock(SimpMessageHeaderAccessor::class.java)
+        `when`(localHeaderAccessor.sessionId).thenReturn("session-3")
+
+        val state = controller.join("Alice", localHeaderAccessor)
+
+        // Sie darf rein, weil sie schon Teil des Spiels ist (kein GAME_FULL Error)
+        assertNotNull(state)
+        assertEquals(2, state?.players?.size)
+    }
 }


### PR DESCRIPTION
**Problem / Zweck**

Als Entwicklerin möchte ich die in Issue #108 implementierte Kernlogik für Farmkäufe über das Netzwerk aufrufbar machen, damit das Frontend Farmen über WebSockets kaufen kann und bei zu wenig Gold eine saubere, verarbeitbare Fehlermeldung erhält.

**Lösung**

* Neuer ErrorCode `INSUFFICIENT_GOLD` in der `ErrorCode` Enum-Klasse ergänzt.
* Neuer STOMP-Endpoint `@MessageMapping("/buyFarm")` im `WebSocketBrokerController` implementiert.
* Der Endpoint sucht den Spieler anhand der Session-ID, prüft dynamisch die Kosten und sendet bei Geldmangel eine gezielte Fehlermeldung (`/queue/errors`) an den auslösenden Spieler zurück.
* Bei erfolgreichem Kauf wird die `buyFarm`-Logik des `GameService` aufgerufen und der neue `GameState` via Broadcast (`/topic/game`) an alle Clients gesendet. Die Serialisierung von `player.farms` im JSON erfolgt automatisch durch die Data Class.
* Die Controller-Tests wurden um Erfolgs- und Fehlerfälle des neuen Endpoints sowie fehlende Edge-Cases (z.B. leere Session-IDs, Reconnects) erweitert. Die Branch-Coverage des Controllers liegt nun bei sicheren 87 %.

Closes #109