### PR TITLE
Feat #74: Farm-Counter, Kauf-Endpoint und Einkommen implementieren

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -100,7 +100,6 @@ class WebSocketBrokerController(
         val cost = GameService.FARM_BASE_COST + (player.farms * GameService.FARM_COST_INCREMENT)
 
         if (player.gold < cost) {
-            // Deine eigene Hilfsfunktion nutzen!
             sendError(sessionId, ErrorCode.INSUFFICIENT_GOLD, "Nicht genug Gold für eine Farm!")
             return null // null returned -> kein Broadcast an alle
         }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -87,6 +87,28 @@ class WebSocketBrokerController(
         return stateAfter
     }
 
+    @MessageMapping("/buyFarm")
+    @SendTo("/topic/game")
+    fun buyFarm(headerAccessor: SimpMessageHeaderAccessor): GameState? {
+        val sessionId = headerAccessor.sessionId ?: ""
+        val state = gameService.getCurrentState()
+
+        // Spieler über die SessionId suchen
+        val player = state.players.find { it.sessionId == sessionId } ?: return null
+
+        // Kosten prüfen
+        val cost = GameService.FARM_BASE_COST + (player.farms * GameService.FARM_COST_INCREMENT)
+
+        if (player.gold < cost) {
+            // Deine eigene Hilfsfunktion nutzen!
+            sendError(sessionId, ErrorCode.INSUFFICIENT_GOLD, "Nicht genug Gold für eine Farm!")
+            return null // null returned -> kein Broadcast an alle
+        }
+
+        // Kauf durchführen und den neuen GameState an /topic/game senden
+        return gameService.buyFarm(state, player.name)
+    }
+
 
     fun handleJoin(name: String, sessionId: String) = gameService.handleJoin(name, sessionId)
     fun handleMove(move: Move) = gameService.handleMove(move)

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/ErrorCode.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/ErrorCode.kt
@@ -4,5 +4,6 @@ enum class ErrorCode {
     NOT_YOUR_TURN,
     INVALID_MOVE,
     GAME_FULL,
-    GAME_NOT_STARTED
+    GAME_NOT_STARTED,
+    INSUFFICIENT_GOLD
 }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -12,6 +12,9 @@ class GameService(
     companion object {
         const val MAX_PLAYERS = 2
         const val STARTING_GOLD = 6
+        const val FARM_INCOME_PER_ROUND = 3
+        const val FARM_BASE_COST = 12
+        const val FARM_COST_INCREMENT = 2
     }
 
     fun handleJoin(state: GameState, playerName: String, sessionId:String=""): GameState = synchronized(state.lock) {
@@ -247,6 +250,9 @@ class GameService(
 
     private fun applyUpkeep(state: GameState) {
         state.players.forEach { player ->
+            // Farm-Einkommen gutschreiben
+            player.gold += player.farms * FARM_INCOME_PER_ROUND
+
             // Skelette herausfiltern, damit sie in Zukunft keinen Unterhalt mehr kosten
             val playerUnits = state.units.filter { it.player == player.name && it.type != UnitType.SKELETON }
             val unitCount = playerUnits.size
@@ -266,5 +272,22 @@ class GameService(
 
         // Prüfen, ob durch Insolvenz ein Spieler alle lebenden Einheiten verloren hat (Win-Condition)
         checkWinCondition(state)
+    }
+
+    fun buyFarm(state: GameState, playerName: String): GameState = synchronized(state.lock) {
+        if (state.status != GameStatus.IN_PROGRESS) return state
+
+        val player = state.players.find { it.name == playerName } ?: return state
+
+        val cost = FARM_BASE_COST + (player.farms * FARM_COST_INCREMENT)
+
+        if (player.gold >= cost) {
+            player.gold -= cost
+            player.farms += 1
+            println("Service: $playerName kaufte Farm für $cost. (Total: ${player.farms})")
+        } else {
+            println("Service: $playerName hat zu wenig Gold ($cost) für Farm.")
+        }
+        return state
     }
 }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Player.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Player.kt
@@ -5,5 +5,6 @@ data class Player (
     val name : String = "",
     val sessionId : String = "",
     val color: PlayerColor = PlayerColor.RED,
-    var gold: Int = 0
+    var gold: Int = 0,
+    var farms: Int = 0
 ){}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -362,4 +362,83 @@ class WebSocketBrokerControllerTest {
             argThat { it is ErrorMessage && it.errorCode == ErrorCode.INVALID_MOVE }
         )
     }
+
+    @Test
+    fun `buyFarm via websocket returns updated state when gold is sufficient`() {
+        controller.handleJoin("Alice", "test-session")
+        controller.handleJoin("Bob", "session-2")
+
+        val state = gameService.getCurrentState()
+        val alice = state.players.first { it.name == "Alice" }
+        alice.gold = 20 // Genug Gold
+
+        // Endpoint aufrufen
+        val result = controller.buyFarm(headerAccessor)
+
+        // Verifizieren, dass der Kauf klappt und der neue State zurückkommt (@SendTo greift)
+        assertNotNull(result)
+        assertEquals(1, result?.players?.first { it.name == "Alice" }?.farms)
+        assertEquals(8, result?.players?.first { it.name == "Alice" }?.gold)
+    }
+
+    @Test
+    fun `buyFarm via websocket sends INSUFFICIENT_GOLD error when poor`() {
+        controller.handleJoin("Alice", "test-session")
+        controller.handleJoin("Bob", "session-2")
+
+        val state = gameService.getCurrentState()
+        val alice = state.players.first { it.name == "Alice" }
+        alice.gold = 5 // Zu wenig Gold
+
+        // Endpoint aufrufen
+        val result = controller.buyFarm(headerAccessor)
+
+        // Verifizieren, dass kein State gebroadcastet wird...
+        assertNull(result)
+
+        // ... sondern stattdessen exakt der Error an den User geschickt wird
+        verify(messagingTemplate).convertAndSendToUser(
+            eq("test-session"),
+            eq("/queue/errors"),
+            argThat { it is ErrorMessage && it.errorCode == ErrorCode.INSUFFICIENT_GOLD }
+        )
+    }
+
+    @Test
+    fun `buyFarm returns null if player session is unknown`() {
+        // Leeres Spiel, niemand ist beigetreten -> headerAccessor hat test-session
+        val result = controller.buyFarm(headerAccessor)
+
+        // Da die Session unbekannt ist, muss der Controller direkt null zurückgeben
+        assertNull(result)
+    }
+
+    @Test
+    fun `buyFarm handles null sessionId from headerAccessor gracefully`() {
+        // Simuliert, dass das Netzwerk keine Session-ID mitschickt
+        val localHeaderAccessor = mock(SimpMessageHeaderAccessor::class.java)
+        `when`(localHeaderAccessor.sessionId).thenReturn(null)
+
+        val result = controller.buyFarm(localHeaderAccessor)
+
+        // Da die Session null (bzw. "") ist, wird kein Spieler gefunden -> null
+        assertNull(result)
+    }
+
+    @Test
+    fun `join allows reconnecting player even if game is max capacity`() {
+        // Spiel ist voll mit Alice und Bob
+        controller.handleJoin("Alice", "session-1")
+        controller.handleJoin("Bob", "session-2")
+
+        // Alice verliert die Verbindung und joint neu mit neuer Session-ID
+        val localHeaderAccessor = mock(SimpMessageHeaderAccessor::class.java)
+        `when`(localHeaderAccessor.sessionId).thenReturn("session-3")
+
+        val state = controller.join("Alice", localHeaderAccessor)
+
+        // Sie darf rein, weil sie schon Teil des Spiels ist (kein GAME_FULL Error)
+        assertNotNull(state)
+        assertEquals(2, state?.players?.size)
+    }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -364,4 +364,63 @@ class GameServiceTest {
         assertThat(state.status).isEqualTo(GameStatus.FINISHED)
         assertThat(state.winner).isEqualTo("Bob")
     }
+
+    @Test
+    fun `test buyFarm - erfolgreicher Kauf erhoeht die Kosten fuer die naechste Farm`() {
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+
+        val state = gameService.getCurrentState()
+        val alice = state.players.first { it.name == "Alice" }
+
+        alice.gold = 30
+
+        gameService.buyFarm(state, "Alice")
+        assertThat(alice.farms).isEqualTo(1)
+        assertThat(alice.gold).isEqualTo(18)
+
+        gameService.buyFarm(state, "Alice")
+        assertThat(alice.farms).isEqualTo(2)
+        assertThat(alice.gold).isEqualTo(4)
+    }
+
+    @Test
+    fun `test buyFarm - schlaegt bei zu wenig Gold fehl`() {
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+
+        val state = gameService.getCurrentState()
+        val alice = state.players.first { it.name == "Alice" }
+
+        alice.gold = 10
+        gameService.buyFarm(state, "Alice")
+
+        assertThat(alice.farms).isEqualTo(0)
+        assertThat(alice.gold).isEqualTo(10)
+    }
+
+    @Test
+    fun `test applyUpkeep - Farm-Einkommen verhindert Insolvenz`() {
+        gameService.initializeGame()
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+        val state = gameService.getCurrentState()
+        val alice = state.players.first { it.name == "Alice" }
+        val bob = state.players.first { it.name == "Bob" }
+
+        alice.farms = 1
+        alice.gold = 9
+        bob.gold = 20
+
+        val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY, aliceInf.x, aliceInf.y, 0, 0))
+        val bobInf = state.units.first { it.player == "Bob" && it.type == UnitType.INFANTRY }
+        gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, 1, 1))
+
+        assertThat(alice.gold).isEqualTo(0)
+        assertThat(alice.farms).isEqualTo(1)
+        assertThat(state.units.filter { it.player == "Alice" }.all { it.type != UnitType.SKELETON }).isTrue()
+    }
 }


### PR DESCRIPTION
**Problem / Zweck**

Das Wirtschaftssystem (Epic #60) benötigt die vollständige Farm-Mechanik, damit Spieler ihr Gold in ein langfristiges Rundeneinkommen investieren können, um die steigenden Truppenkosten zu decken. Dieses Issue fasst die Kernlogik und die Netzwerk-Schnittstelle zusammen.

**Lösung**

Dieses PR integriert die abgeschlossenen Sub-Issues #108 und #109 in den Epic-Branch:
* **Logik & Modell (#108):** Das `farms`-Attribut wurde zum Spieler hinzugefügt. Die `buyFarm`-Funktion mit dynamischer Kostenberechnung und die Einkommensausschüttung in `applyUpkeep` wurden im `GameService` implementiert.
* **Endpoint & Netzwerk (#109):** Der STOMP-Endpoint `@MessageMapping("/buyFarm")` inkl. Validierung und dem neuen ErrorCode `INSUFFICIENT_GOLD` wurde im `WebSocketBrokerController` bereitgestellt. 
* Sämtliche Unit- und Integrationstests (Erfolgsfälle, Error-Handling, Edge-Cases) sind grün. Die Branch-Coverage für Controller und Service liegt sicher über dem 80 % DoD.

Closes #74