### PR TITLE
multi-session/subissue 81 rest api

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomController.kt
@@ -1,0 +1,93 @@
+package at.aau.hexabrawl.websocketserver.controller
+
+import at.aau.hexabrawl.websocketserver.model.GameMode
+import at.aau.hexabrawl.websocketserver.model.Room
+import at.aau.hexabrawl.websocketserver.model.RoomRegistry
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+/**
+ * REST Controller for managing game rooms.
+ * Provides endpoints to create and retrieve game rooms.
+ */
+@RestController
+@RequestMapping("/api/rooms")
+class RoomController(private val roomRegistry: RoomRegistry) {
+
+    /**
+     * POST /api/rooms
+     * Creates a new game room with the specified game mode.
+     *
+     * @param mode The game mode for the new room (default: DUAL_VALLEY).
+     * @return The created room as DTO with status 201.
+     */
+    @PostMapping
+    fun createRoom(
+        @RequestParam(defaultValue = "DUAL_VALLEY") mode: GameMode
+    ): ResponseEntity<RoomDTO> {
+        val room = roomRegistry.createRoom(mode)
+        return ResponseEntity.status(201).body(room.toDTO())
+    }
+
+    /**
+     * GET /api/rooms
+     * Returns all rooms currently waiting for players.
+     *
+     * @return List of open rooms as DTOs.
+     */
+    @GetMapping
+    fun getOpenRooms(): ResponseEntity<List<RoomDTO>> {
+        val openRooms = roomRegistry.getOpenRooms().map { it.toDTO() }
+        return ResponseEntity.ok(openRooms)
+    }
+
+    /**
+     * GET /api/rooms/{roomId}
+     * Returns a single room by its unique roomId.
+     *
+     * @param roomId The unique identifier of the room.
+     * @return The room as DTO or 404 if not found.
+     */
+    @GetMapping("/{roomId}")
+    fun getRoomById(@PathVariable roomId: String): ResponseEntity<RoomDTO> {
+        val room = roomRegistry.findById(roomId)
+        return if (room != null) {
+            ResponseEntity.ok(room.toDTO())
+        } else {
+            ResponseEntity.notFound().build()
+        }
+    }
+}
+
+/**
+ * Data Transfer Object for Room responses.
+ * Prevents serialization issues with internal GameState lock.
+ *
+ * @property roomId Unique identifier of the room.
+ * @property joinCode 6-character code for joining the room.
+ * @property mode The game mode of the room.
+ * @property maxPlayers Maximum number of players allowed.
+ * @property currentPlayers Current number of players in the room.
+ */
+data class RoomDTO(
+    val roomId: String,
+    val joinCode: String,
+    val mode: GameMode,
+    val maxPlayers: Int,
+    val currentPlayers: Int
+)
+
+/**
+ * Extension function to convert a Room to a RoomDTO.
+ *
+ * @return RoomDTO representation of this room.
+ */
+fun Room.toDTO(): RoomDTO {
+    return RoomDTO(
+        roomId = this.roomId,
+        joinCode = this.joinCode,
+        mode = this.mode,
+        maxPlayers = this.maxPlayers,
+        currentPlayers = this.players.size
+    )
+}

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomController.kt
@@ -1,7 +1,6 @@
 package at.aau.hexabrawl.websocketserver.controller
 
 import at.aau.hexabrawl.websocketserver.model.GameMode
-import at.aau.hexabrawl.websocketserver.model.Room
 import at.aau.hexabrawl.websocketserver.model.RoomRegistry
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -57,37 +56,4 @@ class RoomController(private val roomRegistry: RoomRegistry) {
             ResponseEntity.notFound().build()
         }
     }
-}
-
-/**
- * Data Transfer Object for Room responses.
- * Prevents serialization issues with internal GameState lock.
- *
- * @property roomId Unique identifier of the room.
- * @property joinCode 6-character code for joining the room.
- * @property mode The game mode of the room.
- * @property maxPlayers Maximum number of players allowed.
- * @property currentPlayers Current number of players in the room.
- */
-data class RoomDTO(
-    val roomId: String,
-    val joinCode: String,
-    val mode: GameMode,
-    val maxPlayers: Int,
-    val currentPlayers: Int
-)
-
-/**
- * Extension function to convert a Room to a RoomDTO.
- *
- * @return RoomDTO representation of this room.
- */
-fun Room.toDTO(): RoomDTO {
-    return RoomDTO(
-        roomId = this.roomId,
-        joinCode = this.joinCode,
-        mode = this.mode,
-        maxPlayers = this.maxPlayers,
-        currentPlayers = this.players.size
-    )
 }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomDTO.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomDTO.kt
@@ -1,0 +1,37 @@
+package at.aau.hexabrawl.websocketserver.controller
+
+import at.aau.hexabrawl.websocketserver.model.GameMode
+import at.aau.hexabrawl.websocketserver.model.Room
+
+/**
+ * Data Transfer Object for Room responses.
+ * Prevents serialization issues with internal GameState lock.
+ *
+ * @property roomId Unique identifier of the room.
+ * @property joinCode 6-character code for joining the room.
+ * @property mode The game mode of the room.
+ * @property maxPlayers Maximum number of players allowed.
+ * @property currentPlayers Current number of players in the room.
+ */
+data class RoomDTO(
+    val roomId: String,
+    val joinCode: String,
+    val mode: GameMode,
+    val maxPlayers: Int,
+    val currentPlayers: Int
+)
+
+/**
+ * Extension function to convert a Room to a RoomDTO.
+ *
+ * @return RoomDTO representation of this room.
+ */
+fun Room.toDTO(): RoomDTO {
+    return RoomDTO(
+        roomId = this.roomId,
+        joinCode = this.joinCode,
+        mode = this.mode,
+        maxPlayers = this.maxPlayers,
+        currentPlayers = this.players.size
+    )
+}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomControllerTest.kt
@@ -1,0 +1,148 @@
+package at.aau.hexabrawl.websocketserver.controller
+
+import at.aau.hexabrawl.websocketserver.model.GameMode
+import at.aau.hexabrawl.websocketserver.model.GameStatus
+import at.aau.hexabrawl.websocketserver.model.RoomRegistry
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+class RoomControllerTest {
+
+    private lateinit var registry: RoomRegistry
+    private lateinit var controller: RoomController
+
+    @BeforeEach
+    fun setUp() {
+        registry = RoomRegistry()
+        controller = RoomController(registry)
+    }
+
+    // ===== POST /api/rooms =====
+
+    @Test
+    fun `createRoom returns 201`() {
+        val response = controller.createRoom(GameMode.DUAL_VALLEY)
+        assertEquals(HttpStatus.CREATED, response.statusCode)
+    }
+
+    @Test
+    fun `createRoom returns room with correct mode`() {
+        val response = controller.createRoom(GameMode.DUAL_VALLEY)
+        assertEquals(GameMode.DUAL_VALLEY, response.body?.mode)
+    }
+
+    @Test
+    fun `createRoom returns room with joinCode`() {
+        val response = controller.createRoom(GameMode.DUAL_VALLEY)
+        assertNotNull(response.body?.joinCode)
+        assertEquals(6, response.body?.joinCode?.length)
+    }
+
+    @Test
+    fun `createRoom returns room with correct maxPlayers`() {
+        val response = controller.createRoom(GameMode.TRIAD_OUTPOST)
+        assertEquals(3, response.body?.maxPlayers)
+    }
+
+    @Test
+    fun `createRoom returns room with 0 current players`() {
+        val response = controller.createRoom(GameMode.DUAL_VALLEY)
+        assertEquals(0, response.body?.currentPlayers)
+    }
+
+    @Test
+    fun `createRoom works for all game modes`() {
+        val dual = controller.createRoom(GameMode.DUAL_VALLEY)
+        val triad = controller.createRoom(GameMode.TRIAD_OUTPOST)
+        val battle = controller.createRoom(GameMode.BATTLEFIELD_PEAKS)
+
+        assertEquals(GameMode.DUAL_VALLEY, dual.body?.mode)
+        assertEquals(GameMode.TRIAD_OUTPOST, triad.body?.mode)
+        assertEquals(GameMode.BATTLEFIELD_PEAKS, battle.body?.mode)
+    }
+
+    // ===== GET /api/rooms =====
+
+    @Test
+    fun `getOpenRooms returns 200`() {
+        val response = controller.getOpenRooms()
+        assertEquals(HttpStatus.OK, response.statusCode)
+    }
+
+    @Test
+    fun `getOpenRooms returns empty list when no rooms`() {
+        val response = controller.getOpenRooms()
+        assertTrue(response.body?.isEmpty() == true)
+    }
+
+    @Test
+    fun `getOpenRooms returns only WAITING_FOR_PLAYERS rooms`() {
+        controller.createRoom(GameMode.DUAL_VALLEY)
+        val room2 = registry.createRoom(GameMode.DUAL_VALLEY)
+        room2.gameState.status = GameStatus.IN_PROGRESS
+
+        val response = controller.getOpenRooms()
+        assertEquals(1, response.body?.size)
+    }
+
+    @Test
+    fun `getOpenRooms returns all open rooms`() {
+        controller.createRoom(GameMode.DUAL_VALLEY)
+        controller.createRoom(GameMode.TRIAD_OUTPOST)
+
+        val response = controller.getOpenRooms()
+        assertEquals(2, response.body?.size)
+    }
+
+    // ===== GET /api/rooms/{roomId} =====
+
+    @Test
+    fun `getRoomById returns 200 for existing room`() {
+        val created = controller.createRoom(GameMode.DUAL_VALLEY)
+        val roomId = created.body?.roomId!!
+
+        val response = controller.getRoomById(roomId)
+        assertEquals(HttpStatus.OK, response.statusCode)
+    }
+
+    @Test
+    fun `getRoomById returns correct room`() {
+        val created = controller.createRoom(GameMode.DUAL_VALLEY)
+        val roomId = created.body?.roomId!!
+
+        val response = controller.getRoomById(roomId)
+        assertEquals(roomId, response.body?.roomId)
+    }
+
+    @Test
+    fun `getRoomById returns 404 for unknown roomId`() {
+        val response = controller.getRoomById("unknown-id")
+        assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+    }
+
+    @Test
+    fun `getRoomById returns correct joinCode`() {
+        val created = controller.createRoom(GameMode.DUAL_VALLEY)
+        val roomId = created.body?.roomId!!
+        val joinCode = created.body?.joinCode!!
+
+        val response = controller.getRoomById(roomId)
+        assertEquals(joinCode, response.body?.joinCode)
+    }
+
+    // ===== RoomDTO =====
+
+    @Test
+    fun `RoomDTO contains all required fields`() {
+        val response = controller.createRoom(GameMode.DUAL_VALLEY)
+        val dto = response.body!!
+
+        assertNotNull(dto.roomId)
+        assertNotNull(dto.joinCode)
+        assertNotNull(dto.mode)
+        assertNotNull(dto.maxPlayers)
+        assertNotNull(dto.currentPlayers)
+    }
+}


### PR DESCRIPTION
Closes #81

## Änderungen
- `RoomController` mit 3 REST Endpoints implementiert
- `RoomDTO` als separates Data Transfer Object erstellt
- `Room.toDTO()` Extension Function für saubere Konvertierung

## Endpoints
| Method | Path | Beschreibung |
|---|---|---|
| `POST` | `/api/rooms` | Erstellt neuen Raum, gibt 201 zurück |
| `GET` | `/api/rooms` | Listet alle offenen Räume zurück |
| `GET` | `/api/rooms/{roomId}` | Gibt einzelnen Raum zurück, 404 wenn nicht gefunden |

## Warum DTO?
`Room` enthält intern einen `GameState` mit einem `lock` Objekt für Thread-Safety. 
Das DTO verhindert Serialisierungsprobleme und gibt nur die relevanten Felder zurück.

## Tests
- Unit Tests 
- Alle Endpoints mit Postman manuell verifiziert

## Details
Sub-Issue von #51 — Multisession Management