### PR TITLE
multi-session/issue 58 health endpoint extension

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthController.kt
@@ -1,5 +1,6 @@
 package at.aau.hexabrawl.websocketserver.controller
 
+import at.aau.hexabrawl.websocketserver.model.GameStatus
 import at.aau.hexabrawl.websocketserver.model.RoomRegistry
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -16,11 +17,13 @@ class HealthController(
     private val roomRegistry: RoomRegistry
 ) {
 
+    private val startTime = LocalDateTime.now()
+
     /**
      * GET /health
      * Returns server health status including all active rooms and players.
      *
-     * @return Health information including rooms and player counts.
+     * @return Health information including rooms, player counts and uptime.
      */
     @GetMapping("/health")
     fun health(): ResponseEntity<Map<String, Any>> {
@@ -43,9 +46,12 @@ class HealthController(
             "service" to "HexaBrawl Game Server",
             "version" to "1.0.0",
             "timestamp" to LocalDateTime.now().format(formatter),
+            "uptime" to java.time.Duration.between(startTime, LocalDateTime.now()).seconds.toString() + "s",
             "rooms" to roomInfos,
             "totalRooms" to allRooms.size,
-            "totalPlayers" to allRooms.sumOf { it.players.size }
+            "totalPlayers" to allRooms.sumOf { it.players.size },
+            "openRooms" to allRooms.count { it.status == GameStatus.WAITING_FOR_PLAYERS },
+            "activeRooms" to allRooms.count { it.status == GameStatus.IN_PROGRESS }
         ))
     }
 }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthController.kt
@@ -1,30 +1,51 @@
 package at.aau.hexabrawl.websocketserver.controller
 
-import at.aau.hexabrawl.websocketserver.model.GameService
+import at.aau.hexabrawl.websocketserver.model.RoomRegistry
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
+/**
+ * REST Controller for server health information.
+ * Provides server status and active room information.
+ */
 @RestController
 class HealthController(
-    private val gameService: GameService
+    private val roomRegistry: RoomRegistry
 ) {
 
+    /**
+     * GET /health
+     * Returns server health status including all active rooms and players.
+     *
+     * @return Health information including rooms and player counts.
+     */
     @GetMapping("/health")
     fun health(): ResponseEntity<Map<String, Any>> {
         val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-        val state = gameService.getCurrentState()
+        val allRooms = roomRegistry.getAllRooms()
+
+        val roomInfos = allRooms.map { room ->
+            mapOf(
+                "roomId" to room.roomId,
+                "joinCode" to room.joinCode,
+                "mode" to room.mode,
+                "gameStatus" to room.status,
+                "players" to room.players,
+                "maxPlayers" to room.maxPlayers
+            )
+        }
 
         return ResponseEntity.ok(mapOf(
             "status" to "UP",
             "service" to "HexaBrawl Game Server",
             "version" to "1.0.0",
             "timestamp" to LocalDateTime.now().format(formatter),
-            "gameStatus" to state.status.name,
-            "connectedPlayers" to state.players.size,
-            "maxPlayers" to GameService.MAX_PLAYERS
+            "rooms" to roomInfos,
+            "totalRooms" to allRooms.size,
+            "totalPlayers" to allRooms.sumOf { it.players.size }
         ))
     }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthControllerTest.kt
@@ -1,15 +1,21 @@
 package at.aau.hexabrawl.websocketserver.controller
 
-import at.aau.hexabrawl.websocketserver.model.CombatService
-import at.aau.hexabrawl.websocketserver.model.GameService
+import at.aau.hexabrawl.websocketserver.model.*
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 
 class HealthControllerTest {
 
-    private val gameService = GameService(CombatService())
-    private val controller = HealthController(gameService)
+    private lateinit var registry: RoomRegistry
+    private lateinit var controller: HealthController
+
+    @BeforeEach
+    fun setUp() {
+        registry = RoomRegistry()
+        controller = HealthController(registry)
+    }
 
     @Test
     fun `health endpoint returns 200`() {
@@ -42,20 +48,87 @@ class HealthControllerTest {
     }
 
     @Test
-    fun `health endpoint returns game status`() {
+    fun `health endpoint returns empty rooms list when no rooms`() {
         val response = controller.health()
-        assertEquals("WAITING_FOR_PLAYERS", response.body?.get("gameStatus"))
+        @Suppress("UNCHECKED_CAST")
+        val rooms = response.body?.get("rooms") as List<*>
+        assertTrue(rooms.isEmpty())
     }
 
     @Test
-    fun `health endpoint returns connected players count`() {
+    fun `health endpoint returns totalRooms as 0 when no rooms`() {
         val response = controller.health()
-        assertEquals(0, response.body?.get("connectedPlayers"))
+        assertEquals(0, response.body?.get("totalRooms"))
     }
 
     @Test
-    fun `health endpoint returns max players`() {
+    fun `health endpoint returns totalPlayers as 0 when no rooms`() {
         val response = controller.health()
-        assertEquals(2, response.body?.get("maxPlayers"))
+        assertEquals(0, response.body?.get("totalPlayers"))
+    }
+
+    @Test
+    fun `health endpoint returns correct totalRooms`() {
+        registry.createRoom(GameMode.DUAL_VALLEY)
+        registry.createRoom(GameMode.TRIAD_OUTPOST)
+
+        val response = controller.health()
+        assertEquals(2, response.body?.get("totalRooms"))
+    }
+
+    @Test
+    fun `health endpoint returns correct totalPlayers`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+        room.gameState.players.add(Player("Alice", "s1", PlayerColor.RED))
+        room.gameState.players.add(Player("Bob", "s2", PlayerColor.BLUE))
+
+        val response = controller.health()
+        assertEquals(2, response.body?.get("totalPlayers"))
+    }
+
+    @Test
+    fun `health endpoint rooms contain player names`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+        room.gameState.players.add(Player("Alice", "s1", PlayerColor.RED))
+
+        val response = controller.health()
+        @Suppress("UNCHECKED_CAST")
+        val rooms = response.body?.get("rooms") as List<Map<String, Any>>
+        val players = rooms[0]["players"] as List<*>
+
+        assertTrue(players.contains("Alice"))
+    }
+
+    @Test
+    fun `health endpoint rooms contain roomId`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+
+        val response = controller.health()
+        @Suppress("UNCHECKED_CAST")
+        val rooms = response.body?.get("rooms") as List<Map<String, Any>>
+
+        assertEquals(room.roomId, rooms[0]["roomId"])
+    }
+
+    @Test
+    fun `health endpoint rooms contain joinCode`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+
+        val response = controller.health()
+        @Suppress("UNCHECKED_CAST")
+        val rooms = response.body?.get("rooms") as List<Map<String, Any>>
+
+        assertEquals(room.joinCode, rooms[0]["joinCode"])
+    }
+
+    @Test
+    fun `health endpoint rooms contain maxPlayers`() {
+        registry.createRoom(GameMode.TRIAD_OUTPOST)
+
+        val response = controller.health()
+        @Suppress("UNCHECKED_CAST")
+        val rooms = response.body?.get("rooms") as List<Map<String, Any>>
+
+        assertEquals(3, rooms[0]["maxPlayers"])
     }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/HealthControllerTest.kt
@@ -131,4 +131,33 @@ class HealthControllerTest {
 
         assertEquals(3, rooms[0]["maxPlayers"])
     }
+
+    @Test
+    fun `health endpoint returns uptime`() {
+        val response = controller.health()
+        assertNotNull(response.body?.get("uptime"))
+        assertTrue(response.body?.get("uptime").toString().endsWith("s"))
+    }
+
+    @Test
+    fun `health endpoint returns openRooms count`() {
+        registry.createRoom(GameMode.DUAL_VALLEY)
+        val response = controller.health()
+        assertEquals(1, response.body?.get("openRooms"))
+    }
+
+    @Test
+    fun `health endpoint returns activeRooms count`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+        room.gameState.status = GameStatus.IN_PROGRESS
+        val response = controller.health()
+        assertEquals(1, response.body?.get("activeRooms"))
+    }
+
+    @Test
+    fun `health endpoint returns 0 activeRooms when no active rooms`() {
+        registry.createRoom(GameMode.DUAL_VALLEY)
+        val response = controller.health()
+        assertEquals(0, response.body?.get("activeRooms"))
+    }
 }


### PR DESCRIPTION
## Änderungen
- `GameService` durch `RoomRegistry` im `HealthController` ersetzt
- Health Endpoint zeigt jetzt alle aktiven Räume mit Details
- Spielernamen pro Raum werden angezeigt
- `uptime` — Serverzeit seit Start hinzugefügt
- `openRooms` — Anzahl Räume die noch Spieler suchen
- `activeRooms` — Anzahl Räume wo gerade gespielt wird

## Beispielantwort
```json
{
  "status": "UP",
  "service": "HexaBrawl Game Server",
  "version": "1.0.0",
  "timestamp": "2026-06-01 14:23:45",
  "uptime": "127s",
  "rooms": [
    {
      "roomId": "...",
      "joinCode": "ABC123",
      "mode": "DUAL_VALLEY",
      "gameStatus": "IN_PROGRESS",
      "players": ["Alice", "Bob"],
      "maxPlayers": 2
    }
  ],
  "totalRooms": 1,
  "totalPlayers": 2,
  "openRooms": 0,
  "activeRooms": 1
}
```

## Tests
- Unit Tests 