### PR TITLE
Feat/61 bewegung eroberung player color join request

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -5,7 +5,9 @@ import at.aau.hexabrawl.websocketserver.model.ErrorMessage
 import at.aau.hexabrawl.websocketserver.model.GameService
 import at.aau.hexabrawl.websocketserver.model.GameState
 import at.aau.hexabrawl.websocketserver.model.GameStatus
+import at.aau.hexabrawl.websocketserver.model.JoinRequest
 import at.aau.hexabrawl.websocketserver.model.Move
+import at.aau.hexabrawl.websocketserver.model.PlayerColor
 import at.aau.hexabrawl.websocketserver.model.StompMessage
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.SendTo
@@ -39,20 +41,32 @@ class WebSocketBrokerController(
     @MessageMapping("/join")
     @SendTo("/topic/game")
     fun join(
-        playerName: String,
+        request: JoinRequest,
         headerAccessor: SimpMessageHeaderAccessor
     ): GameState? {
 
         val sessionId = headerAccessor.sessionId ?: ""
         val currentState = gameService.getCurrentState()
 
+        // Spiel voll?
         if (currentState.players.size >= GameService.MAX_PLAYERS &&
-            !currentState.players.any { it.name == playerName }) {
+            !currentState.players.any { it.name == request.name }) {
             sendError(sessionId, ErrorCode.GAME_FULL, "Beitritt verweigert: Spiel ist voll.")
             return null
         }
 
-        return gameService.handleJoin(playerName, sessionId)
+        // Farb-Konflikt: Nur pruefen wenn Spieler neu ist (Re-Join mit gleichem Namen ist okay).
+        if (!currentState.players.any { it.name == request.name } &&
+            gameService.isColorTaken(request.color)) {
+            sendError(
+                sessionId,
+                ErrorCode.COLOR_ALREADY_TAKEN,
+                "Beitritt verweigert: Farbe '${request.color}' ist bereits vergeben."
+            )
+            return null
+        }
+
+        return gameService.handleJoin(request.name, sessionId, request.color)
     }
 
     @MessageMapping("/init")
@@ -89,7 +103,8 @@ class WebSocketBrokerController(
     }
 
 
-    fun handleJoin(name: String, sessionId: String) = gameService.handleJoin(name, sessionId)
+    fun handleJoin(name: String, sessionId: String, color: PlayerColor? = null) =
+        gameService.handleJoin(name, sessionId, color)
     fun handleMove(move: Move) = gameService.handleMove(move)
 
     private fun sendError(user: String, code: ErrorCode, msg: String) {

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/ErrorCode.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/ErrorCode.kt
@@ -4,5 +4,6 @@ enum class ErrorCode {
     NOT_YOUR_TURN,
     INVALID_MOVE,
     GAME_FULL,
-    GAME_NOT_STARTED
+    GAME_NOT_STARTED,
+    COLOR_ALREADY_TAKEN
 }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -20,13 +20,21 @@ class GameService(
         val BASE_POSITION_P2: Pair<Int, Int> = Pair(6, 7)
     }
 
-    fun handleJoin(state: GameState, playerName: String, sessionId:String=""): GameState = synchronized(state.lock) {
+    fun handleJoin(
+        state: GameState,
+        playerName: String,
+        sessionId: String = "",
+        color: PlayerColor? = null
+    ): GameState = synchronized(state.lock) {
         // Spieler hinzufügen, falls noch nicht vorhanden und Platz ist
 
         if (!state.players.any{it.name == playerName} && state.players.size < MAX_PLAYERS) {
-            val color = if (state.players.isEmpty()) PlayerColor.RED else PlayerColor.BLUE
-            state.players.add(Player(playerName, sessionId,color))
-            println("JOIN: $playerName")
+            // Wenn Color vom Client angegeben → nimm diese.
+            // Sonst Fallback auf alte Logik (Backward-Compat fuer Tests / alten Client).
+            val assignedColor = color
+                ?: if (state.players.isEmpty()) PlayerColor.RED else PlayerColor.BLUE
+            state.players.add(Player(playerName, sessionId, assignedColor))
+            println("JOIN: $playerName (color: $assignedColor)")
         }
 
         // Automatischer Start bei 2 Spielern
@@ -73,8 +81,9 @@ class GameService(
     //Bridge Method handleJoin
     fun handleJoin(
         playerName: String,
-        sessionId: String = ""
-    ): GameState = handleJoin(this.gameState, playerName, sessionId)
+        sessionId: String = "",
+        color: PlayerColor? = null
+    ): GameState = handleJoin(this.gameState, playerName, sessionId, color)
 
     fun handleMove(state: GameState, move: Move): GameState = synchronized(state.lock) {
         if (state.status != GameStatus.IN_PROGRESS) return state

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -33,6 +33,13 @@ class GameService(
             // Sonst Fallback auf alte Logik (Backward-Compat fuer Tests / alten Client).
             val assignedColor = color
                 ?: if (state.players.isEmpty()) PlayerColor.RED else PlayerColor.BLUE
+
+            // Color-Konflikt: zweiter Spieler darf nicht die gleiche Farbe haben.
+            // Defensiv hier ablehnen - die Error-Response macht der Controller.
+            if (state.players.any { it.color == assignedColor }) {
+                return@synchronized state
+            }
+
             state.players.add(Player(playerName, sessionId, assignedColor))
             println("JOIN: $playerName (color: $assignedColor)")
         }
@@ -84,6 +91,18 @@ class GameService(
         sessionId: String = "",
         color: PlayerColor? = null
     ): GameState = handleJoin(this.gameState, playerName, sessionId, color)
+
+    /**
+     * Prueft ob eine Farbe bereits einem Spieler zugewiesen wurde.
+     * Wird vom Controller genutzt, um einen Farb-Konflikt zu erkennen
+     * und dem Client eine entsprechende Error-Response zu schicken.
+     */
+    fun isColorTaken(state: GameState, color: PlayerColor): Boolean = synchronized(state.lock) {
+        return state.players.any { it.color == color }
+    }
+
+    //Bridge Method isColorTaken
+    fun isColorTaken(color: PlayerColor): Boolean = isColorTaken(this.gameState, color)
 
     fun handleMove(state: GameState, move: Move): GameState = synchronized(state.lock) {
         if (state.status != GameStatus.IN_PROGRESS) return state

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/JoinRequest.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/JoinRequest.kt
@@ -1,0 +1,14 @@
+package at.aau.hexabrawl.websocketserver.model
+
+/**
+ * DTO für den Join-Request des Clients.
+ *
+ * Wird als JSON über STOMP an /app/join gesendet:
+ *   { "name": "Alice", "color": "RED" }
+ *
+ * Spring/Jackson deserialisiert das automatisch in diese data class.
+ */
+data class JoinRequest(
+    val name: String = "",
+    val color: PlayerColor = PlayerColor.RED
+)

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/PlayerColor.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/PlayerColor.kt
@@ -1,5 +1,5 @@
 package at.aau.hexabrawl.websocketserver.model
 
 enum class PlayerColor {
-    RED,BLUE
+    RED, BLUE, GREEN, YELLOW
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -407,4 +407,48 @@ class WebSocketBrokerControllerTest {
 
         assertEquals("Bob", result?.currentTurn)
     }
+
+    // ---- Color-Tests fuer Sub-Issue #107 --------------------------------
+
+    @Test
+    fun `join applies color from JoinRequest`() {
+        `when`(headerAccessor.sessionId).thenReturn("session-1")
+
+        val state = controller.join(
+            JoinRequest(name = "Alice", color = PlayerColor.GREEN),
+            headerAccessor
+        )!!
+
+        assertEquals(PlayerColor.GREEN, state.players[0].color)
+    }
+
+    @Test
+    fun `join with duplicate color sends COLOR_ALREADY_TAKEN error`() {
+        controller.handleJoin("Alice", "session-1", PlayerColor.RED)
+
+        val secondHeaderAccessor = mock(SimpMessageHeaderAccessor::class.java)
+        `when`(secondHeaderAccessor.sessionId).thenReturn("session-2")
+
+        val result = controller.join(
+            JoinRequest(name = "Bob", color = PlayerColor.RED),
+            secondHeaderAccessor
+        )
+
+        assertNull(result)
+        verify(messagingTemplate).convertAndSendToUser(
+            eq("session-2"),
+            eq("/queue/errors"),
+            argThat { it is ErrorMessage && it.errorCode == ErrorCode.COLOR_ALREADY_TAKEN }
+        )
+    }
+
+    @Test
+    fun `PlayerColor supports all four colors`() {
+        assertEquals(4, PlayerColor.entries.size)
+        assertTrue(
+            PlayerColor.entries.containsAll(
+                listOf(PlayerColor.RED, PlayerColor.BLUE, PlayerColor.GREEN, PlayerColor.YELLOW)
+            )
+        )
+    }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -190,7 +190,7 @@ class WebSocketBrokerControllerTest {
     fun `game stays waiting when only one player joins`() {
         val localHeaderAccessor = SimpMessageHeaderAccessor.create()
 
-        val state = controller.join("Alice", localHeaderAccessor)!!
+        val state = controller.join(JoinRequest(name = "Alice"), localHeaderAccessor)!!
 
         assertEquals(1, state.players.size)
         assertEquals(GameStatus.WAITING_FOR_PLAYERS, state.status)
@@ -270,7 +270,7 @@ class WebSocketBrokerControllerTest {
         `when`(localHeaderAccessor.sessionId).thenReturn(null)
 
         val state = controller.join(
-            "Alice",
+            JoinRequest(name = "Alice"),
             localHeaderAccessor
         )!!
 
@@ -287,7 +287,7 @@ class WebSocketBrokerControllerTest {
         `when`(localHeaderAccessor.sessionId).thenReturn("session-1")
 
         val state = controller.join(
-            "Josef",
+            JoinRequest(name = "Josef"),
             localHeaderAccessor
         )!!
 
@@ -303,7 +303,7 @@ class WebSocketBrokerControllerTest {
         controller.handleJoin("P1", "session-1")
         controller.handleJoin("P2", "session-2")
 
-        val result = controller.join("P3", headerAccessor)
+        val result = controller.join(JoinRequest(name = "P3"), headerAccessor)
 
         assertNull(result)
         verify(messagingTemplate).convertAndSendToUser(


### PR DESCRIPTION
## Summary


Erweitert den Server um 4 Spielerfarben (RED, BLUE, GREEN, YELLOW) und 
nimmt die in der Wartelobby gewählte Farbe via JoinRequest entgegen.

## Changes
- `PlayerColor`: Enum erweitert auf 4 Farben
- `JoinRequest`: Neue DTO für JSON-basierten Join
- `WebSocketBrokerController.join`: Akzeptiert JoinRequest statt String, 
  validiert Color-Konflikte
- `GameService.handleJoin`: Optionaler Color-Parameter (Backward-Compat)
- `ErrorCode.COLOR_ALREADY_TAKEN`: Neue Error-Variante
- Tests angepasst + neue Tests für Color-Funktionalität

## Note on file count
PR berührt 6 Dateien (über dem üblichen 4-Datei-Limit). Jede Änderung ist 
direkt von den Akzeptanzkriterien abgeleitet — keine unrelated Refactorings.
Das Test-File-Update ist forciert durch die geänderte Controller-Signatur.

## Test plan
- [x] Bestehende Tests grün
- [x] Neuer Test: Color aus JoinRequest landet am Player
- [x] Neuer Test: Doppelte Farbe → COLOR_ALREADY_TAKEN
- [x] Neuer Test: Alle 4 Farben sind verfügbar