### PR TITLE
Implement room-specific STOMP endpoints and broadcasts (#83)

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -58,6 +58,16 @@ class WebSocketBrokerController(
         return gameService.handleJoin(playerName, sessionId)
     }
 
+    /**
+     * Broadcasts the current game state to all subscribers of the specified room.
+     *
+     * The state is sent to the room-specific STOMP topic
+     * "/topic/rooms/{roomId}/state", ensuring that only clients subscribed
+     * to this room receive the update.
+     *
+     * @param roomId Unique identifier of the room whose state is broadcast.
+     * @param state Current game state of the room.
+     */
     private fun sendRoomState(
         roomId: String,
         state: GameState
@@ -68,6 +78,20 @@ class WebSocketBrokerController(
         )
     }
 
+    /**
+     * Adds a player to the specified game room.
+     *
+     * The room is identified by its unique roomId. If the room exists and is not
+     * full, the player is added to the room's game state and the updated state is
+     * broadcast to all subscribers of the room-specific topic.
+     *
+     * If the room does not exist, a ROOM_NOT_FOUND error is sent to the client.
+     *
+     * @param roomId Unique identifier of the target room.
+     * @param playerName Name of the player joining the room.
+     * @param headerAccessor Provides access to the STOMP session information.
+     * @return Updated GameState if the player was successfully added; null otherwise.
+     */
     @MessageMapping("/rooms/{roomId}/join")
     fun joinRoom(
         @DestinationVariable roomId: String,
@@ -122,6 +146,19 @@ class WebSocketBrokerController(
         return gameService.getCurrentState()
     }
 
+    /**
+     * Returns the current game state of the specified room.
+     *
+     * The room is identified by its unique roomId. The current state is
+     * broadcast to all subscribers of the room-specific topic and returned
+     * to the requesting client.
+     *
+     * If the room does not exist, a ROOM_NOT_FOUND error is sent to the client.
+     *
+     * @param roomId Unique identifier of the requested room.
+     * @param headerAccessor Provides access to the STOMP session information.
+     * @return Current GameState of the room, or null if the room does not exist.
+     */
     @MessageMapping("/rooms/{roomId}/init")
     fun initRoom(
         @DestinationVariable roomId: String,
@@ -178,6 +215,22 @@ class WebSocketBrokerController(
         return stateAfter
     }
 
+    /**
+     * Executes a move in the specified game room.
+     *
+     * The room is identified by its unique roomId. The move is validated against
+     * the room's current game state. If the move is valid, the updated game state
+     * is broadcast to all subscribers of the room-specific topic.
+     *
+     * If the room does not exist, a ROOM_NOT_FOUND error is sent to the client.
+     * Additional errors are reported if the game has not started, it is not the
+     * player's turn, or the move is invalid.
+     *
+     * @param roomId Unique identifier of the target room.
+     * @param move The move to be executed.
+     * @param headerAccessor Provides access to the STOMP session information.
+     * @return Updated GameState after a successful move; null otherwise.
+     */
     @MessageMapping("/rooms/{roomId}/move")
     fun moveRoom(
         @DestinationVariable roomId: String,

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -58,6 +58,16 @@ class WebSocketBrokerController(
         return gameService.handleJoin(playerName, sessionId)
     }
 
+    private fun sendRoomState(
+        roomId: String,
+        state: GameState
+    ) {
+        messagingTemplate.convertAndSend(
+            "/topic/rooms/$roomId/state",
+            state
+        )
+    }
+
     @MessageMapping("/rooms/{roomId}/join")
     fun joinRoom(
         @DestinationVariable roomId: String,
@@ -66,7 +76,15 @@ class WebSocketBrokerController(
     ): GameState? {
 
         val room = roomRegistry.findById(roomId)
-            ?: return null
+
+        if (room == null) {
+            sendError(
+                headerAccessor.sessionId ?: "",
+                ErrorCode.ROOM_NOT_FOUND,
+                "Raum nicht gefunden."
+            )
+            return null
+        }
 
         val sessionId = headerAccessor.sessionId ?: ""
 
@@ -84,11 +102,18 @@ class WebSocketBrokerController(
             return null
         }
 
-        return gameService.handleJoin(
+        val state = gameService.handleJoin(
             room.gameState,
             playerName,
             sessionId
         )
+
+        sendRoomState(
+            roomId,
+            state
+        )
+
+        return state
     }
 
     @MessageMapping("/init")
@@ -99,14 +124,31 @@ class WebSocketBrokerController(
 
     @MessageMapping("/rooms/{roomId}/init")
     fun initRoom(
-        @DestinationVariable roomId: String
+        @DestinationVariable roomId: String,
+        headerAccessor: SimpMessageHeaderAccessor
     ): GameState? {
-        val room = roomRegistry.findById(roomId)
-            ?: return null
 
-        return gameService.getCurrentState(
+        val sessionId = headerAccessor.sessionId ?: ""
+        val room = roomRegistry.findById(roomId)
+        if (room == null) {
+            sendError(
+                sessionId,
+                ErrorCode.ROOM_NOT_FOUND,
+                "Raum nicht gefunden."
+            )
+            return null
+        }
+
+        val state = gameService.getCurrentState(
             room.gameState
         )
+
+        sendRoomState(
+            roomId,
+            state
+        )
+
+        return state
     }
 
     @MessageMapping("/move")
@@ -144,7 +186,15 @@ class WebSocketBrokerController(
     ): GameState? {
 
         val room = roomRegistry.findById(roomId)
-            ?: return null
+
+        if (room == null) {
+            sendError(
+                headerAccessor.sessionId ?: "",
+                ErrorCode.ROOM_NOT_FOUND,
+                "Raum nicht gefunden."
+            )
+            return null
+        }
 
         val sessionId = headerAccessor.sessionId ?: ""
 
@@ -183,6 +233,11 @@ class WebSocketBrokerController(
             )
             return null
         }
+
+        sendRoomState(
+            roomId,
+            stateAfter
+        )
 
         return stateAfter
     }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -136,6 +136,57 @@ class WebSocketBrokerController(
         return stateAfter
     }
 
+    @MessageMapping("/rooms/{roomId}/move")
+    fun moveRoom(
+        @DestinationVariable roomId: String,
+        move: Move,
+        headerAccessor: SimpMessageHeaderAccessor
+    ): GameState? {
+
+        val room = roomRegistry.findById(roomId)
+            ?: return null
+
+        val sessionId = headerAccessor.sessionId ?: ""
+
+        val stateBefore = gameService.getCurrentState(room.gameState)
+
+        if (stateBefore.status != GameStatus.IN_PROGRESS) {
+            sendError(
+                sessionId,
+                ErrorCode.GAME_NOT_STARTED,
+                "Zug abgelehnt: Spiel läuft nicht."
+            )
+            return null
+        }
+
+        if (move.player != stateBefore.currentTurn) {
+            sendError(
+                sessionId,
+                ErrorCode.NOT_YOUR_TURN,
+                "Es ist nicht dein Zug!"
+            )
+            return null
+        }
+
+        val turnBefore = stateBefore.currentTurn
+
+        val stateAfter = gameService.handleMove(
+            room.gameState,
+            move
+        )
+
+        if (stateAfter.currentTurn == turnBefore) {
+            sendError(
+                sessionId,
+                ErrorCode.INVALID_MOVE,
+                "Dieser Zug ist laut Regeln ungültig."
+            )
+            return null
+        }
+
+        return stateAfter
+    }
+
 
     fun handleJoin(name: String, sessionId: String) = gameService.handleJoin(name, sessionId)
     fun handleMove(move: Move) = gameService.handleMove(move)

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -26,6 +26,10 @@ class WebSocketBrokerController(
     private val roomRegistry: RoomRegistry,
     private val messagingTemplate: SimpMessagingTemplate
 ) {
+    companion object {
+        private const val ROOM_NOT_FOUND_MESSAGE =
+            "Raum nicht gefunden."
+    }
 
     @MessageMapping("/hello")
     @SendTo("/topic/hello-response")
@@ -105,7 +109,7 @@ class WebSocketBrokerController(
             sendError(
                 headerAccessor.sessionId ?: "",
                 ErrorCode.ROOM_NOT_FOUND,
-                "Raum nicht gefunden."
+                ROOM_NOT_FOUND_MESSAGE
             )
             return null
         }
@@ -171,7 +175,7 @@ class WebSocketBrokerController(
             sendError(
                 sessionId,
                 ErrorCode.ROOM_NOT_FOUND,
-                "Raum nicht gefunden."
+                ROOM_NOT_FOUND_MESSAGE
             )
             return null
         }
@@ -244,7 +248,7 @@ class WebSocketBrokerController(
             sendError(
                 headerAccessor.sessionId ?: "",
                 ErrorCode.ROOM_NOT_FOUND,
-                "Raum nicht gefunden."
+                ROOM_NOT_FOUND_MESSAGE
             )
             return null
         }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -6,7 +6,9 @@ import at.aau.hexabrawl.websocketserver.model.GameService
 import at.aau.hexabrawl.websocketserver.model.GameState
 import at.aau.hexabrawl.websocketserver.model.GameStatus
 import at.aau.hexabrawl.websocketserver.model.Move
+import at.aau.hexabrawl.websocketserver.model.RoomRegistry
 import at.aau.hexabrawl.websocketserver.model.StompMessage
+import org.springframework.messaging.handler.annotation.DestinationVariable
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.SendTo
 import org.springframework.stereotype.Controller
@@ -21,6 +23,7 @@ import org.springframework.messaging.simp.annotation.SendToUser
 @Controller
 class WebSocketBrokerController(
     private val gameService: GameService,
+    private val roomRegistry: RoomRegistry,
     private val messagingTemplate: SimpMessagingTemplate
 ) {
 
@@ -59,6 +62,18 @@ class WebSocketBrokerController(
     @SendTo("/topic/game")
     fun init(): GameState {
         return gameService.getCurrentState()
+    }
+
+    @MessageMapping("/rooms/{roomId}/init")
+    fun initRoom(
+        @DestinationVariable roomId: String
+    ): GameState? {
+        val room = roomRegistry.findById(roomId)
+            ?: return null
+
+        return gameService.getCurrentState(
+            room.gameState
+        )
     }
 
     @MessageMapping("/move")

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -58,6 +58,39 @@ class WebSocketBrokerController(
         return gameService.handleJoin(playerName, sessionId)
     }
 
+    @MessageMapping("/rooms/{roomId}/join")
+    fun joinRoom(
+        @DestinationVariable roomId: String,
+        playerName: String,
+        headerAccessor: SimpMessageHeaderAccessor
+    ): GameState? {
+
+        val room = roomRegistry.findById(roomId)
+            ?: return null
+
+        val sessionId = headerAccessor.sessionId ?: ""
+
+        val currentState = gameService.getCurrentState(room.gameState)
+
+        if (currentState.players.size >= GameService.MAX_PLAYERS &&
+            !currentState.players.any { it.name == playerName }) {
+
+            sendError(
+                sessionId,
+                ErrorCode.GAME_FULL,
+                "Beitritt verweigert: Spiel ist voll."
+            )
+
+            return null
+        }
+
+        return gameService.handleJoin(
+            room.gameState,
+            playerName,
+            sessionId
+        )
+    }
+
     @MessageMapping("/init")
     @SendTo("/topic/game")
     fun init(): GameState {

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/ErrorCode.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/ErrorCode.kt
@@ -4,5 +4,6 @@ enum class ErrorCode {
     NOT_YOUR_TURN,
     INVALID_MOVE,
     GAME_FULL,
-    GAME_NOT_STARTED
+    GAME_NOT_STARTED,
+    ROOM_NOT_FOUND
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -402,7 +402,7 @@ class WebSocketBrokerControllerTest {
 
     @Test
     fun `initRoom returns null for invalid room id`() {
-        val result = controller.initRoom("invalid-room-id")
+        val result = controller.initRoom("invalid-room-id", headerAccessor)
 
         assertNull(result)
     }
@@ -416,7 +416,7 @@ class WebSocketBrokerControllerTest {
             Player("Josef", "session1", PlayerColor.RED)
         )
 
-        val result = controller.initRoom(room.roomId)
+        val result = controller.initRoom(room.roomId, headerAccessor)
 
         assertNotNull(result)
         assertEquals(1, result!!.players.size)
@@ -511,6 +511,156 @@ class WebSocketBrokerControllerTest {
         )
 
         assertNull(result)
+    }
+
+    @Test
+    fun `initRoom broadcasts state to room topic`() {
+
+        val room = roomRegistry.createRoom(
+            GameMode.DUAL_VALLEY
+        )
+
+        controller.initRoom(room.roomId, headerAccessor)
+
+        verify(messagingTemplate).convertAndSend(
+            "/topic/rooms/${room.roomId}/state",
+            room.gameState
+        )
+    }
+
+    @Test
+    fun `joinRoom broadcasts state to room topic`() {
+
+        val room = roomRegistry.createRoom(
+            GameMode.DUAL_VALLEY
+        )
+
+        val headerAccessor = SimpMessageHeaderAccessor.create()
+
+        controller.joinRoom(
+            room.roomId,
+            "Josef",
+            headerAccessor
+        )
+
+        verify(messagingTemplate).convertAndSend(
+            "/topic/rooms/${room.roomId}/state",
+            room.gameState
+        )
+    }
+
+    @Test
+    fun `moveRoom broadcasts state to room topic`() {
+
+        val room = roomRegistry.createRoom(
+            GameMode.DUAL_VALLEY
+        )
+
+        val headerAccessor = SimpMessageHeaderAccessor.create()
+
+        gameService.handleJoin(
+            room.gameState,
+            "Josef",
+            "session-1"
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "Marie",
+            "session-2"
+        )
+
+        val move = Move(
+            player = "Josef",
+            type = UnitType.INFANTRY,
+            fromX = 3,
+            fromY = 2,
+            toX = 3,
+            toY = 3
+        )
+
+        controller.moveRoom(
+            room.roomId,
+            move,
+            headerAccessor
+        )
+
+        verify(messagingTemplate).convertAndSend(
+            "/topic/rooms/${room.roomId}/state",
+            room.gameState
+        )
+    }
+
+    @Test
+    fun `initRoom sends ROOM_NOT_FOUND for invalid room id`() {
+        val headerAccessor = SimpMessageHeaderAccessor.create()
+
+        controller.initRoom(
+            "invalid-room-id",
+            headerAccessor
+        )
+
+        verify(messagingTemplate).convertAndSendToUser(
+            anyString(),
+            eq("/queue/errors"),
+            eq(
+                ErrorMessage(
+                    ErrorCode.ROOM_NOT_FOUND,
+                    "Raum nicht gefunden."
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `joinRoom sends ROOM_NOT_FOUND for invalid room id`() {
+
+        controller.joinRoom(
+            "invalid-room-id",
+            "Josef",
+            headerAccessor
+        )
+
+        verify(messagingTemplate).convertAndSendToUser(
+            anyString(),
+            eq("/queue/errors"),
+            eq(
+                ErrorMessage(
+                    ErrorCode.ROOM_NOT_FOUND,
+                    "Raum nicht gefunden."
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `moveRoom sends ROOM_NOT_FOUND for invalid room id`() {
+
+        val move = Move(
+            player = "Josef",
+            type = UnitType.INFANTRY,
+            fromX = 0,
+            fromY = 0,
+            toX = 1,
+            toY = 0
+        )
+
+        controller.moveRoom(
+            "invalid-room-id",
+            move,
+            headerAccessor
+        )
+
+        verify(messagingTemplate).convertAndSendToUser(
+            anyString(),
+            eq("/queue/errors"),
+            eq(
+                ErrorMessage(
+                    ErrorCode.ROOM_NOT_FOUND,
+                    "Raum nicht gefunden."
+                )
+            )
+        )
     }
 
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -15,11 +15,12 @@ class WebSocketBrokerControllerTest {
     private lateinit var gameService: GameService
     private lateinit var messagingTemplate: SimpMessagingTemplate // Neu für Issue #24
     private lateinit var headerAccessor: SimpMessageHeaderAccessor // Neu für Issue #24
+    private lateinit var roomRegistry: RoomRegistry
 
     @BeforeEach
     fun setup() {
         gameService = GameService(CombatService())
-        val roomRegistry = RoomRegistry()
+        roomRegistry = RoomRegistry()
         messagingTemplate = mock(SimpMessagingTemplate::class.java) // Mock erstellen
         controller = WebSocketBrokerController(gameService, roomRegistry, messagingTemplate)
 
@@ -405,4 +406,61 @@ class WebSocketBrokerControllerTest {
 
         assertNull(result)
     }
+
+    @Test
+    fun `initRoom returns state of requested room`() {
+
+        val room = roomRegistry.createRoom(GameMode.DUAL_VALLEY)
+
+        room.gameState.players.add(
+            Player("Alice", "session1", PlayerColor.RED)
+        )
+
+        val result = controller.initRoom(room.roomId)
+
+        assertNotNull(result)
+        assertEquals(1, result!!.players.size)
+        assertEquals("Alice", result.players[0].name)
+    }
+
+    @Test
+    fun `joinRoom returns null for invalid room id`() {
+
+        val headerAccessor = SimpMessageHeaderAccessor.create()
+
+        val result = controller.joinRoom(
+            "invalid-room-id",
+            "Alice",
+            headerAccessor
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `joinRoom adds player to requested room`() {
+
+        val room = roomRegistry.createRoom(
+            GameMode.DUAL_VALLEY
+        )
+
+        val headerAccessor = SimpMessageHeaderAccessor.create()
+
+        controller.joinRoom(
+            room.roomId,
+            "Alice",
+            headerAccessor
+        )
+
+        assertEquals(
+            1,
+            room.gameState.players.size
+        )
+
+        assertEquals(
+            "Alice",
+            room.gameState.players[0].name
+        )
+    }
+
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -19,8 +19,9 @@ class WebSocketBrokerControllerTest {
     @BeforeEach
     fun setup() {
         gameService = GameService(CombatService())
+        val roomRegistry = RoomRegistry()
         messagingTemplate = mock(SimpMessagingTemplate::class.java) // Mock erstellen
-        controller = WebSocketBrokerController(gameService, messagingTemplate)
+        controller = WebSocketBrokerController(gameService, roomRegistry, messagingTemplate)
 
         headerAccessor = mock(SimpMessageHeaderAccessor::class.java)
         `when`(headerAccessor.sessionId).thenReturn("test-session")
@@ -396,5 +397,12 @@ class WebSocketBrokerControllerTest {
         assertNotNull(result)
 
         assertEquals("Bob", result?.currentTurn)
+    }
+
+    @Test
+    fun `initRoom returns null for invalid room id`() {
+        val result = controller.initRoom("invalid-room-id")
+
+        assertNull(result)
     }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -413,14 +413,14 @@ class WebSocketBrokerControllerTest {
         val room = roomRegistry.createRoom(GameMode.DUAL_VALLEY)
 
         room.gameState.players.add(
-            Player("Alice", "session1", PlayerColor.RED)
+            Player("Josef", "session1", PlayerColor.RED)
         )
 
         val result = controller.initRoom(room.roomId)
 
         assertNotNull(result)
         assertEquals(1, result!!.players.size)
-        assertEquals("Alice", result.players[0].name)
+        assertEquals("Josef", result.players[0].name)
     }
 
     @Test
@@ -430,7 +430,7 @@ class WebSocketBrokerControllerTest {
 
         val result = controller.joinRoom(
             "invalid-room-id",
-            "Alice",
+            "Josef",
             headerAccessor
         )
 
@@ -448,7 +448,7 @@ class WebSocketBrokerControllerTest {
 
         controller.joinRoom(
             room.roomId,
-            "Alice",
+            "Josef",
             headerAccessor
         )
 
@@ -458,9 +458,59 @@ class WebSocketBrokerControllerTest {
         )
 
         assertEquals(
-            "Alice",
+            "Josef",
             room.gameState.players[0].name
         )
+    }
+
+    @Test
+    fun `moveRoom returns null for invalid room id`() {
+
+        val headerAccessor = SimpMessageHeaderAccessor.create()
+
+        val move = Move(
+            player = "Josef",
+            type = UnitType.INFANTRY,
+            fromX = 0,
+            fromY = 0,
+            toX = 1,
+            toY = 0
+        )
+
+        val result = controller.moveRoom(
+            "invalid-room-id",
+            move,
+            headerAccessor
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `moveRoom returns null when game not started`() {
+
+        val room = roomRegistry.createRoom(
+            GameMode.DUAL_VALLEY
+        )
+
+        val headerAccessor = SimpMessageHeaderAccessor.create()
+
+        val move = Move(
+            player = "Josef",
+            type = UnitType.INFANTRY,
+            fromX = 0,
+            fromY = 0,
+            toX = 1,
+            toY = 0
+        )
+
+        val result = controller.moveRoom(
+            room.roomId,
+            move,
+            headerAccessor
+        )
+
+        assertNull(result)
     }
 
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -663,4 +663,136 @@ class WebSocketBrokerControllerTest {
         )
     }
 
+    @Test
+    fun `joinRoom sends GAME_FULL when room is full`() {
+
+        val room = roomRegistry.createRoom(
+            GameMode.DUAL_VALLEY
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "Benno",
+            "session-1"
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "Josef",
+            "session-2"
+        )
+
+        val result = controller.joinRoom(
+            room.roomId,
+            "Marie",
+            headerAccessor
+        )
+
+        assertNull(result)
+
+        verify(messagingTemplate).convertAndSendToUser(
+            anyString(),
+            eq("/queue/errors"),
+            eq(
+                ErrorMessage(
+                    ErrorCode.GAME_FULL,
+                    "Beitritt verweigert: Spiel ist voll."
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `moveRoom sends NOT_YOUR_TURN`() {
+
+        val room = roomRegistry.createRoom(
+            GameMode.DUAL_VALLEY
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "Josef",
+            "session-1"
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "Marie",
+            "session-2"
+        )
+
+        val move = Move(
+            player = "Marie",
+            type = UnitType.INFANTRY,
+            fromX = 3,
+            fromY = 2,
+            toX = 3,
+            toY = 3
+        )
+
+        val result = controller.moveRoom(
+            room.roomId,
+            move,
+            headerAccessor
+        )
+
+        assertNull(result)
+
+        verify(messagingTemplate).convertAndSendToUser(
+            anyString(),
+            eq("/queue/errors"),
+            eq(
+                ErrorMessage(
+                    ErrorCode.NOT_YOUR_TURN,
+                    "Es ist nicht dein Zug!"
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `moveRoom sends INVALID_MOVE`() {
+
+        val room = roomRegistry.createRoom(
+            GameMode.DUAL_VALLEY
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "P1",
+            "session-1"
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "P2",
+            "session-2"
+        )
+
+        val move = Move(
+            player = "P1",
+            fromX = 0,
+            fromY = 0,
+            toX = 9,
+            toY = 9
+        )
+
+        val result = controller.moveRoom(
+            room.roomId,
+            move,
+            headerAccessor
+        )
+
+        assertNull(result)
+
+        verify(messagingTemplate).convertAndSendToUser(
+            eq("test-session"),
+            eq("/queue/errors"),
+            argThat {
+                it is ErrorMessage &&
+                        it.errorCode == ErrorCode.INVALID_MOVE
+            }
+        )
+    }
+
 }


### PR DESCRIPTION
## Summary

Implements room-specific STOMP mappings as part of the Multisession Management feature (#51).

### Changes

* Added `/app/rooms/{roomId}/init`
* Added `/app/rooms/{roomId}/join`
* Added `/app/rooms/{roomId}/move`
* Added room-specific broadcasts via `/topic/rooms/{roomId}/state`
* Added `ROOM_NOT_FOUND` error handling for invalid room IDs
* Added KDocs for newly introduced methods
* Added unit tests for success and error paths

### Acceptance Criteria

* [x] STOMP Mapping `/app/rooms/{roomId}/join`
* [x] STOMP Mapping `/app/rooms/{roomId}/move`
* [x] STOMP Mapping `/app/rooms/{roomId}/init`
* [x] Broadcast only to subscribers of the corresponding room
* [x] Error handling for invalid room IDs
* [x] KDocs added
* [x] Unit tests added

### Testing

All tests pass successfully.

Coverage highlights:

* Controller line coverage: 99%
* Controller branch coverage: 92%

### Notes

The existing global endpoints (`/join`, `/move`, `/init`) remain unchanged and will be removed in follow-up issue #86.
