### PR TITLE
multi-session/sub issue 82 room garbage collection

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/WebSocketDemoServerApplication.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/WebSocketDemoServerApplication.kt
@@ -2,8 +2,10 @@ package at.aau.hexabrawl.websocketserver
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
+@EnableScheduling
 class WebSocketDemoServerApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomController.kt
@@ -2,6 +2,7 @@ package at.aau.hexabrawl.websocketserver.controller
 
 import at.aau.hexabrawl.websocketserver.model.GameMode
 import at.aau.hexabrawl.websocketserver.model.RoomRegistry
+import at.aau.hexabrawl.websocketserver.model.RoomCleanupService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.*
  */
 @RestController
 @RequestMapping("/api/rooms")
-class RoomController(private val roomRegistry: RoomRegistry) {
+class RoomController(private val roomRegistry: RoomRegistry, private val cleanupService: RoomCleanupService) {
 
     /**
      * POST /api/rooms
@@ -25,6 +26,7 @@ class RoomController(private val roomRegistry: RoomRegistry) {
         @RequestParam(defaultValue = "DUAL_VALLEY") mode: GameMode
     ): ResponseEntity<RoomDTO> {
         val room = roomRegistry.createRoom(mode)
+        cleanupService.trackRoom(room.roomId)  // ← hinzufügen
         return ResponseEntity.status(201).body(room.toDTO())
     }
 

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupService.kt
@@ -1,19 +1,23 @@
 package at.aau.hexabrawl.websocketserver.model
 
+import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Service that automatically removes inactive rooms from the registry.
  * Runs periodically in the background to prevent server overload.
+ * Broadcasts a closure notification to room subscribers when a room is removed.
  */
 @Service
 class RoomCleanupService(
-    private val roomRegistry: RoomRegistry
+    private val roomRegistry: RoomRegistry,
+    private val messagingTemplate: SimpMessagingTemplate
 ) {
 
-    private val roomCreationTimes = java.util.concurrent.ConcurrentHashMap<String, LocalDateTime>()
+    private val roomCreationTimes = ConcurrentHashMap<String, LocalDateTime>()
     private val lock = Any()
 
     companion object {
@@ -33,6 +37,7 @@ class RoomCleanupService(
 
     /**
      * Removes rooms that are FINISHED or have no players after 5 minutes.
+     * Broadcasts a closure notification to room subscribers before removing.
      * Runs automatically every minute in the background.
      */
     @Scheduled(fixedDelay = 60000)
@@ -49,6 +54,9 @@ class RoomCleanupService(
         }.keys
 
         roomsToRemove.forEach { roomId ->
+            val destination = "/topic/rooms/$roomId/closed"
+            val payload: Any = mapOf("roomId" to roomId, "reason" to "Room expired")
+            messagingTemplate.convertAndSend(destination, payload)
             roomRegistry.removeRoom(roomId)
             roomCreationTimes.remove(roomId)
             println("CleanupService: Room $roomId removed")

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupService.kt
@@ -1,0 +1,66 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+/**
+ * Service that automatically removes inactive rooms from the registry.
+ * Runs periodically in the background to prevent server overload.
+ */
+@Service
+class RoomCleanupService(
+    private val roomRegistry: RoomRegistry
+) {
+
+    private val roomCreationTimes = java.util.concurrent.ConcurrentHashMap<String, LocalDateTime>()
+    private val lock = Any()
+
+    companion object {
+        /** Time in minutes after which inactive rooms are removed. */
+        const val CLEANUP_THRESHOLD_MINUTES = 5L
+    }
+
+    /**
+     * Tracks the creation time of a room.
+     * Should be called when a room is created.
+     *
+     * @param roomId The unique identifier of the room.
+     */
+    fun trackRoom(roomId: String) = synchronized(lock) {
+        roomCreationTimes[roomId] = LocalDateTime.now()
+    }
+
+    /**
+     * Removes rooms that are FINISHED or have no players after 5 minutes.
+     * Runs automatically every minute in the background.
+     */
+    @Scheduled(fixedDelay = 60000)
+    fun cleanupInactiveRooms() = synchronized(lock) {
+        val threshold = LocalDateTime.now().minusMinutes(CLEANUP_THRESHOLD_MINUTES)
+
+        val roomsToRemove = roomCreationTimes.filter { (roomId, createdAt) ->
+            if (createdAt.isBefore(threshold)) {
+                val room = roomRegistry.findById(roomId)
+                room == null ||
+                        room.status == GameStatus.FINISHED ||
+                        room.players.isEmpty()
+            } else false
+        }.keys
+
+        roomsToRemove.forEach { roomId ->
+            roomRegistry.removeRoom(roomId)
+            roomCreationTimes.remove(roomId)
+            println("CleanupService: Room $roomId removed")
+        }
+    }
+
+    /**
+     * Returns the number of currently tracked rooms.
+     *
+     * @return Number of tracked rooms.
+     */
+    fun getTrackedRoomCount(): Int = synchronized(lock) {
+        roomCreationTimes.size
+    }
+}

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupService.kt
@@ -1,5 +1,6 @@
 package at.aau.hexabrawl.websocketserver.model
 
+import org.slf4j.LoggerFactory
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
@@ -21,6 +22,7 @@ class RoomCleanupService(
     private val lock = Any()
 
     companion object {
+        private val log = LoggerFactory.getLogger(RoomCleanupService::class.java)
         /** Time in minutes after which inactive rooms are removed. */
         const val CLEANUP_THRESHOLD_MINUTES = 5L
     }
@@ -30,9 +32,10 @@ class RoomCleanupService(
      * Should be called when a room is created.
      *
      * @param roomId The unique identifier of the room.
+     * @param time The timestamp to register (Defaults to now, can be overridden for testing).
      */
-    fun trackRoom(roomId: String) = synchronized(lock) {
-        roomCreationTimes[roomId] = LocalDateTime.now()
+    fun trackRoom(roomId: String, time: LocalDateTime = LocalDateTime.now()) = synchronized(lock) {
+        roomCreationTimes[roomId] = time
     }
 
     /**
@@ -41,25 +44,34 @@ class RoomCleanupService(
      * Runs automatically every minute in the background.
      */
     @Scheduled(fixedDelay = 60000)
-    fun cleanupInactiveRooms() = synchronized(lock) {
-        val threshold = LocalDateTime.now().minusMinutes(CLEANUP_THRESHOLD_MINUTES)
+    fun cleanupInactiveRooms() {
+        // 1. Snapshot der IDs holen, die zeitlich abgelaufen sind (minimiert Lock-Dauer)
+        val expiredRoomIds = synchronized(lock) {
+            val threshold = LocalDateTime.now().minusMinutes(CLEANUP_THRESHOLD_MINUTES)
+            roomCreationTimes.filter { it.value.isBefore(threshold) }.keys.toList()
+        }
 
-        val roomsToRemove = roomCreationTimes.filter { (roomId, createdAt) ->
-            if (createdAt.isBefore(threshold)) {
-                val room = roomRegistry.findById(roomId)
-                room == null ||
-                        room.status == GameStatus.FINISHED ||
-                        room.players.isEmpty()
-            } else false
-        }.keys
+        // 2. Für jede abgelaufene ID den aktuellen Registry-Zustand prüfen und sicher löschen
+        expiredRoomIds.forEach { roomId ->
+            val room = roomRegistry.findById(roomId)
 
-        roomsToRemove.forEach { roomId ->
-            val destination = "/topic/rooms/$roomId/closed"
-            val payload: Any = mapOf("roomId" to roomId, "reason" to "Room expired")
-            messagingTemplate.convertAndSend(destination, payload)
-            roomRegistry.removeRoom(roomId)
-            roomCreationTimes.remove(roomId)
-            println("CleanupService: Room $roomId removed")
+            // Verhindert Race Conditions: Nochmaliger Check des aktuellen Zustands kurz vor dem Löschen
+            val shouldRemove = room == null ||
+                    room.status == GameStatus.FINISHED ||
+                    room.players.isEmpty()
+
+            if (shouldRemove) {
+                val destination = "/topic/rooms/$roomId/closed"
+                val payload: Any = mapOf("roomId" to roomId, "reason" to "Room expired")
+                messagingTemplate.convertAndSend(destination, payload)
+
+                roomRegistry.removeRoom(roomId)
+
+                synchronized(lock) {
+                    roomCreationTimes.remove(roomId)
+                }
+                log.info("CleanupService: Room {} removed due to inactivity", roomId)
+            }
         }
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 server.port=8080
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=always
+spring.task.scheduling.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,3 @@
 server.port=8080
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=always
-spring.task.scheduling.enabled=true

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomControllerTest.kt
@@ -2,6 +2,7 @@ package at.aau.hexabrawl.websocketserver.controller
 
 import at.aau.hexabrawl.websocketserver.model.GameMode
 import at.aau.hexabrawl.websocketserver.model.GameStatus
+import at.aau.hexabrawl.websocketserver.model.RoomCleanupService
 import at.aau.hexabrawl.websocketserver.model.RoomRegistry
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -11,12 +12,14 @@ import org.springframework.http.HttpStatus
 class RoomControllerTest {
 
     private lateinit var registry: RoomRegistry
+    private lateinit var cleanupService: RoomCleanupService
     private lateinit var controller: RoomController
 
     @BeforeEach
     fun setUp() {
         registry = RoomRegistry()
-        controller = RoomController(registry)
+        cleanupService = RoomCleanupService(registry)
+        controller = RoomController(registry, cleanupService)
     }
 
     // ===== POST /api/rooms =====

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomControllerTest.kt
@@ -7,7 +7,9 @@ import at.aau.hexabrawl.websocketserver.model.RoomRegistry
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
 import org.springframework.http.HttpStatus
+import org.springframework.messaging.simp.SimpMessagingTemplate
 
 class RoomControllerTest {
 
@@ -18,7 +20,8 @@ class RoomControllerTest {
     @BeforeEach
     fun setUp() {
         registry = RoomRegistry()
-        cleanupService = RoomCleanupService(registry)
+        val messagingTemplate = mock(SimpMessagingTemplate::class.java)
+        cleanupService = RoomCleanupService(registry, messagingTemplate)
         controller = RoomController(registry, cleanupService)
     }
 

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupServiceTest.kt
@@ -111,7 +111,7 @@ class RoomCleanupServiceTest {
 
         verify(messagingTemplate).convertAndSend(
             eq("/topic/rooms/${room.roomId}/closed"),
-            any(Object::class.java)
+            any(Any::class.java)
         )
     }
 
@@ -131,6 +131,6 @@ class RoomCleanupServiceTest {
         field.isAccessible = true
         @Suppress("UNCHECKED_CAST")
         val times = field.get(cleanupService) as ConcurrentHashMap<String, LocalDateTime>
-        times[roomId] = java.time.LocalDateTime.now().minusMinutes(minutes)
+        times[roomId] = LocalDateTime.now().minusMinutes(minutes)
     }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupServiceTest.kt
@@ -3,16 +3,24 @@ package at.aau.hexabrawl.websocketserver.model
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import java.time.LocalDateTime
+import java.util.concurrent.ConcurrentHashMap
 
 class RoomCleanupServiceTest {
 
     private lateinit var registry: RoomRegistry
     private lateinit var cleanupService: RoomCleanupService
+    private lateinit var messagingTemplate: SimpMessagingTemplate
 
     @BeforeEach
     fun setUp() {
         registry = RoomRegistry()
-        cleanupService = RoomCleanupService(registry)
+        messagingTemplate = mock(SimpMessagingTemplate::class.java)
+        cleanupService = RoomCleanupService(registry, messagingTemplate)
     }
 
     @Test
@@ -47,12 +55,7 @@ class RoomCleanupServiceTest {
         val room = registry.createRoom(GameMode.DUAL_VALLEY)
         room.gameState.status = GameStatus.FINISHED
 
-        // Simuliere alten Zeitstempel über Reflection
-        val field = RoomCleanupService::class.java.getDeclaredField("roomCreationTimes")
-        field.isAccessible = true
-        @Suppress("UNCHECKED_CAST")
-        val times = field.get(cleanupService) as java.util.concurrent.ConcurrentHashMap<String, java.time.LocalDateTime>
-        times[room.roomId] = java.time.LocalDateTime.now().minusMinutes(6)
+        setRoomAge(room.roomId, 6)
 
         cleanupService.cleanupInactiveRooms()
 
@@ -64,11 +67,7 @@ class RoomCleanupServiceTest {
     fun `cleanupInactiveRooms removes empty rooms after threshold`() {
         val room = registry.createRoom(GameMode.DUAL_VALLEY)
 
-        val field = RoomCleanupService::class.java.getDeclaredField("roomCreationTimes")
-        field.isAccessible = true
-        @Suppress("UNCHECKED_CAST")
-        val times = field.get(cleanupService) as java.util.concurrent.ConcurrentHashMap<String, java.time.LocalDateTime>
-        times[room.roomId] = java.time.LocalDateTime.now().minusMinutes(6)
+        setRoomAge(room.roomId, 6)
 
         cleanupService.cleanupInactiveRooms()
 
@@ -81,11 +80,7 @@ class RoomCleanupServiceTest {
         room.gameState.players.add(Player("Alice", "s1", PlayerColor.RED))
         room.gameState.status = GameStatus.IN_PROGRESS
 
-        val field = RoomCleanupService::class.java.getDeclaredField("roomCreationTimes")
-        field.isAccessible = true
-        @Suppress("UNCHECKED_CAST")
-        val times = field.get(cleanupService) as java.util.concurrent.ConcurrentHashMap<String, java.time.LocalDateTime>
-        times[room.roomId] = java.time.LocalDateTime.now().minusMinutes(6)
+        setRoomAge(room.roomId, 6)
 
         cleanupService.cleanupInactiveRooms()
 
@@ -99,13 +94,43 @@ class RoomCleanupServiceTest {
 
     @Test
     fun `cleanupInactiveRooms handles unknown roomId gracefully`() {
-        val field = RoomCleanupService::class.java.getDeclaredField("roomCreationTimes")
-        field.isAccessible = true
-        @Suppress("UNCHECKED_CAST")
-        val times = field.get(cleanupService) as java.util.concurrent.ConcurrentHashMap<String, java.time.LocalDateTime>
-        times["non-existent-id"] = java.time.LocalDateTime.now().minusMinutes(6)
+        setRoomAge("non-existent-id", 6)
 
         assertDoesNotThrow { cleanupService.cleanupInactiveRooms() }
         assertEquals(0, cleanupService.getTrackedRoomCount())
+    }
+
+    @Test
+    fun `cleanupInactiveRooms broadcasts closed event before removing room`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+        room.gameState.status = GameStatus.FINISHED
+
+        setRoomAge(room.roomId, 6)
+
+        cleanupService.cleanupInactiveRooms()
+
+        verify(messagingTemplate).convertAndSend(
+            eq("/topic/rooms/${room.roomId}/closed"),
+            any(Object::class.java)
+        )
+    }
+
+    @Test
+    fun `cleanupInactiveRooms does not broadcast for fresh rooms`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+        cleanupService.trackRoom(room.roomId)
+
+        cleanupService.cleanupInactiveRooms()
+
+        verifyNoInteractions(messagingTemplate)
+    }
+
+    // Helper Funktion
+    private fun setRoomAge(roomId: String, minutes: Long) {
+        val field = RoomCleanupService::class.java.getDeclaredField("roomCreationTimes")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val times = field.get(cleanupService) as ConcurrentHashMap<String, LocalDateTime>
+        times[roomId] = java.time.LocalDateTime.now().minusMinutes(minutes)
     }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupServiceTest.kt
@@ -8,7 +8,6 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.eq
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import java.time.LocalDateTime
-import java.util.concurrent.ConcurrentHashMap
 
 class RoomCleanupServiceTest {
 
@@ -55,7 +54,8 @@ class RoomCleanupServiceTest {
         val room = registry.createRoom(GameMode.DUAL_VALLEY)
         room.gameState.status = GameStatus.FINISHED
 
-        setRoomAge(room.roomId)
+        // Nutzt jetzt den optionalen Parameter statt Reflection
+        cleanupService.trackRoom(room.roomId, LocalDateTime.now().minusMinutes(6))
 
         cleanupService.cleanupInactiveRooms()
 
@@ -67,7 +67,7 @@ class RoomCleanupServiceTest {
     fun `cleanupInactiveRooms removes empty rooms after threshold`() {
         val room = registry.createRoom(GameMode.DUAL_VALLEY)
 
-        setRoomAge(room.roomId)
+        cleanupService.trackRoom(room.roomId, LocalDateTime.now().minusMinutes(6))
 
         cleanupService.cleanupInactiveRooms()
 
@@ -80,7 +80,7 @@ class RoomCleanupServiceTest {
         room.gameState.players.add(Player("Alice", "s1", PlayerColor.RED))
         room.gameState.status = GameStatus.IN_PROGRESS
 
-        setRoomAge(room.roomId)
+        cleanupService.trackRoom(room.roomId, LocalDateTime.now().minusMinutes(6))
 
         cleanupService.cleanupInactiveRooms()
 
@@ -94,7 +94,7 @@ class RoomCleanupServiceTest {
 
     @Test
     fun `cleanupInactiveRooms handles unknown roomId gracefully`() {
-        setRoomAge("non-existent-id")
+        cleanupService.trackRoom("non-existent-id", LocalDateTime.now().minusMinutes(6))
 
         assertDoesNotThrow { cleanupService.cleanupInactiveRooms() }
         assertEquals(0, cleanupService.getTrackedRoomCount())
@@ -105,7 +105,7 @@ class RoomCleanupServiceTest {
         val room = registry.createRoom(GameMode.DUAL_VALLEY)
         room.gameState.status = GameStatus.FINISHED
 
-        setRoomAge(room.roomId)
+        cleanupService.trackRoom(room.roomId, LocalDateTime.now().minusMinutes(6))
 
         cleanupService.cleanupInactiveRooms()
 
@@ -123,14 +123,5 @@ class RoomCleanupServiceTest {
         cleanupService.cleanupInactiveRooms()
 
         verifyNoInteractions(messagingTemplate)
-    }
-
-    // Helper Funktion
-    private fun setRoomAge(roomId: String) {
-        val field = RoomCleanupService::class.java.getDeclaredField("roomCreationTimes")
-        field.isAccessible = true
-        @Suppress("UNCHECKED_CAST")
-        val times = field.get(cleanupService) as ConcurrentHashMap<String, LocalDateTime>
-        times[roomId] = LocalDateTime.now().minusMinutes(6)
     }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupServiceTest.kt
@@ -55,7 +55,7 @@ class RoomCleanupServiceTest {
         val room = registry.createRoom(GameMode.DUAL_VALLEY)
         room.gameState.status = GameStatus.FINISHED
 
-        setRoomAge(room.roomId, 6)
+        setRoomAge(room.roomId)
 
         cleanupService.cleanupInactiveRooms()
 
@@ -67,7 +67,7 @@ class RoomCleanupServiceTest {
     fun `cleanupInactiveRooms removes empty rooms after threshold`() {
         val room = registry.createRoom(GameMode.DUAL_VALLEY)
 
-        setRoomAge(room.roomId, 6)
+        setRoomAge(room.roomId)
 
         cleanupService.cleanupInactiveRooms()
 
@@ -80,7 +80,7 @@ class RoomCleanupServiceTest {
         room.gameState.players.add(Player("Alice", "s1", PlayerColor.RED))
         room.gameState.status = GameStatus.IN_PROGRESS
 
-        setRoomAge(room.roomId, 6)
+        setRoomAge(room.roomId)
 
         cleanupService.cleanupInactiveRooms()
 
@@ -94,7 +94,7 @@ class RoomCleanupServiceTest {
 
     @Test
     fun `cleanupInactiveRooms handles unknown roomId gracefully`() {
-        setRoomAge("non-existent-id", 6)
+        setRoomAge("non-existent-id")
 
         assertDoesNotThrow { cleanupService.cleanupInactiveRooms() }
         assertEquals(0, cleanupService.getTrackedRoomCount())
@@ -105,7 +105,7 @@ class RoomCleanupServiceTest {
         val room = registry.createRoom(GameMode.DUAL_VALLEY)
         room.gameState.status = GameStatus.FINISHED
 
-        setRoomAge(room.roomId, 6)
+        setRoomAge(room.roomId)
 
         cleanupService.cleanupInactiveRooms()
 
@@ -126,11 +126,11 @@ class RoomCleanupServiceTest {
     }
 
     // Helper Funktion
-    private fun setRoomAge(roomId: String, minutes: Long) {
+    private fun setRoomAge(roomId: String) {
         val field = RoomCleanupService::class.java.getDeclaredField("roomCreationTimes")
         field.isAccessible = true
         @Suppress("UNCHECKED_CAST")
         val times = field.get(cleanupService) as ConcurrentHashMap<String, LocalDateTime>
-        times[roomId] = LocalDateTime.now().minusMinutes(minutes)
+        times[roomId] = LocalDateTime.now().minusMinutes(6)
     }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupServiceTest.kt
@@ -1,0 +1,111 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class RoomCleanupServiceTest {
+
+    private lateinit var registry: RoomRegistry
+    private lateinit var cleanupService: RoomCleanupService
+
+    @BeforeEach
+    fun setUp() {
+        registry = RoomRegistry()
+        cleanupService = RoomCleanupService(registry)
+    }
+
+    @Test
+    fun `trackRoom adds room to tracked rooms`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+        cleanupService.trackRoom(room.roomId)
+        assertEquals(1, cleanupService.getTrackedRoomCount())
+    }
+
+    @Test
+    fun `trackRoom tracks multiple rooms`() {
+        val room1 = registry.createRoom(GameMode.DUAL_VALLEY)
+        val room2 = registry.createRoom(GameMode.TRIAD_OUTPOST)
+        cleanupService.trackRoom(room1.roomId)
+        cleanupService.trackRoom(room2.roomId)
+        assertEquals(2, cleanupService.getTrackedRoomCount())
+    }
+
+    @Test
+    fun `cleanupInactiveRooms does not remove fresh rooms`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+        cleanupService.trackRoom(room.roomId)
+
+        cleanupService.cleanupInactiveRooms()
+
+        assertNotNull(registry.findById(room.roomId))
+        assertEquals(1, cleanupService.getTrackedRoomCount())
+    }
+
+    @Test
+    fun `cleanupInactiveRooms removes FINISHED rooms after threshold`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+        room.gameState.status = GameStatus.FINISHED
+
+        // Simuliere alten Zeitstempel über Reflection
+        val field = RoomCleanupService::class.java.getDeclaredField("roomCreationTimes")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val times = field.get(cleanupService) as java.util.concurrent.ConcurrentHashMap<String, java.time.LocalDateTime>
+        times[room.roomId] = java.time.LocalDateTime.now().minusMinutes(6)
+
+        cleanupService.cleanupInactiveRooms()
+
+        assertNull(registry.findById(room.roomId))
+        assertEquals(0, cleanupService.getTrackedRoomCount())
+    }
+
+    @Test
+    fun `cleanupInactiveRooms removes empty rooms after threshold`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+
+        val field = RoomCleanupService::class.java.getDeclaredField("roomCreationTimes")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val times = field.get(cleanupService) as java.util.concurrent.ConcurrentHashMap<String, java.time.LocalDateTime>
+        times[room.roomId] = java.time.LocalDateTime.now().minusMinutes(6)
+
+        cleanupService.cleanupInactiveRooms()
+
+        assertNull(registry.findById(room.roomId))
+    }
+
+    @Test
+    fun `cleanupInactiveRooms keeps active rooms with players`() {
+        val room = registry.createRoom(GameMode.DUAL_VALLEY)
+        room.gameState.players.add(Player("Alice", "s1", PlayerColor.RED))
+        room.gameState.status = GameStatus.IN_PROGRESS
+
+        val field = RoomCleanupService::class.java.getDeclaredField("roomCreationTimes")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val times = field.get(cleanupService) as java.util.concurrent.ConcurrentHashMap<String, java.time.LocalDateTime>
+        times[room.roomId] = java.time.LocalDateTime.now().minusMinutes(6)
+
+        cleanupService.cleanupInactiveRooms()
+
+        assertNotNull(registry.findById(room.roomId))
+    }
+
+    @Test
+    fun `getTrackedRoomCount returns 0 when no rooms tracked`() {
+        assertEquals(0, cleanupService.getTrackedRoomCount())
+    }
+
+    @Test
+    fun `cleanupInactiveRooms handles unknown roomId gracefully`() {
+        val field = RoomCleanupService::class.java.getDeclaredField("roomCreationTimes")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val times = field.get(cleanupService) as java.util.concurrent.ConcurrentHashMap<String, java.time.LocalDateTime>
+        times["non-existent-id"] = java.time.LocalDateTime.now().minusMinutes(6)
+
+        assertDoesNotThrow { cleanupService.cleanupInactiveRooms() }
+        assertEquals(0, cleanupService.getTrackedRoomCount())
+    }
+}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomRegistryTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomRegistryTest.kt
@@ -125,4 +125,26 @@ class RoomRegistryTest {
         latch.await()
         assertEquals(threadCount, registry.getAllRooms().size)
     }
+
+    @Test
+    fun `createRoom supports 40 parallel rooms`() {
+        repeat(40) { registry.createRoom(GameMode.DUAL_VALLEY) }
+        assertEquals(40, registry.getAllRooms().size)
+    }
+
+    @Test
+    fun `createRoom works for all game modes`() {
+        val dual = registry.createRoom(GameMode.DUAL_VALLEY)
+        val triad = registry.createRoom(GameMode.TRIAD_OUTPOST)
+        val battle = registry.createRoom(GameMode.BATTLEFIELD_PEAKS)
+
+        assertEquals(GameMode.DUAL_VALLEY, dual.mode)
+        assertEquals(GameMode.TRIAD_OUTPOST, triad.mode)
+        assertEquals(GameMode.BATTLEFIELD_PEAKS, battle.mode)
+    }
+
+    @Test
+    fun `getOpenRooms returns empty list when no rooms exist`() {
+        assertTrue(registry.getOpenRooms().isEmpty())
+    }
 }


### PR DESCRIPTION
Closes #82

## Änderungen
- `RoomCleanupService` implementiert mit automatischer Garbage Collection
- Räume in Status `FINISHED` werden nach 5 Minuten entfernt
- Räume ohne aktive Spieler werden nach 5 Minuten entfernt
- Cleanup läuft automatisch jede Minute im Hintergrund (`@Scheduled`)
- `@EnableScheduling` in `WebSocketDemoServerApplication` aktiviert
- `RoomCleanupService` in `RoomController` integriert
- Unit Tests vorhanden
- Mit Postman verifiziert

## Wie es funktioniert
1. Beim Erstellen eines Raums wird die Erstellungszeit getrackt
2. Jede Minute prüft der Service alle Räume
3. Räume die älter als 5 Minuten sind und `FINISHED` oder leer sind werden gelöscht
4. Thread-safe mit `synchronized`

## Details
Sub-Issue von #51 — Multisession Management