### PR TITLE
Feat/61 bewegung eroberung check max 2 hex fields

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -12,6 +12,10 @@ class GameService(
     companion object {
         const val MAX_PLAYERS = 2
 
+        // Maximale Hex-Distanz, die eine Einheit pro Zug zuruecklegen darf.
+        // Spielregel: jede Einheit darf bis zu 2 Felder weit ziehen.
+        const val MAX_MOVE_DISTANCE = 2
+
         // Basis-Positionen für DUAL_VALLEY-Modus (8x8-Grid).
         // Bewusst an die Grid-Raender gesetzt, damit haeufige Test-Move-Ziele
         // wie (6,6) oder (3,1) frei bleiben - sonst blockiert friendlyOnTarget
@@ -90,6 +94,11 @@ class GameService(
                     it.x == move.fromX &&
                     it.y == move.fromY
         } ?: return state
+
+        // Distanz pruefen: zu weite Zuege werden abgelehnt, ebenso "Null-Zuege"
+        // auf das Startfeld. Der Controller wandelt das in INVALID_MOVE um.
+        val distance = HexDistance.between(move.fromX, move.fromY, move.toX, move.toY)
+        if (distance == 0 || distance > MAX_MOVE_DISTANCE) return state
 
         val friendlyOnTarget = state.units.any {
             it.x == move.toX && it.y == move.toY && it.player == move.player

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/HexDistance.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/HexDistance.kt
@@ -1,0 +1,44 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import kotlin.math.abs
+
+/**
+ * Hex-Grid Distanz-Berechnung fuer "odd-q offset" Koordinaten
+ * (gleiches Schema wie im Frontend HexGridLogic verwendet).
+ *
+ * Eine direkte Manhattan-Distanz (|dx| + |dy|) waere falsch, weil
+ * Hex-Felder versetzt liegen. Stattdessen konvertieren wir in cube
+ * coordinates und berechnen dort die Distanz korrekt.
+ *
+ * Pure object, ohne Seiteneffekte oder State.
+ */
+object HexDistance {
+
+    /**
+     * Distanz zwischen zwei Hex-Feldern in "odd-q offset" Koordinaten.
+     *
+     * @param fromX Spalte des Startfelds
+     * @param fromY Zeile des Startfelds
+     * @param toX Spalte des Zielfelds
+     * @param toY Zeile des Zielfelds
+     * @return Anzahl der Hex-Schritte zwischen den Feldern (>= 0)
+     */
+    fun between(fromX: Int, fromY: Int, toX: Int, toY: Int): Int {
+        val (fromXCube, fromYCube, fromZCube) = oddQToCube(fromX, fromY)
+        val (toXCube, toYCube, toZCube) = oddQToCube(toX, toY)
+        return (abs(fromXCube - toXCube) +
+                abs(fromYCube - toYCube) +
+                abs(fromZCube - toZCube)) / 2
+    }
+
+    /**
+     * Konvertiert "odd-q offset" Koordinaten in cube coordinates.
+     * In odd-q offset sind ungerade Spalten nach unten verschoben.
+     */
+    private fun oddQToCube(col: Int, row: Int): Triple<Int, Int, Int> {
+        val x = col
+        val z = row - (col - (col and 1)) / 2
+        val y = -x - z
+        return Triple(x, y, z)
+    }
+}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -407,4 +407,53 @@ class WebSocketBrokerControllerTest {
 
         assertEquals("Bob", result?.currentTurn)
     }
+
+    // ---- Tests fuer Move-Distanz-Validierung (Sub-Issue #102) -----------
+
+    @Test
+    fun `move further than 2 hex fields is rejected`() {
+        controller.handleJoin("Alice", "session-1")
+        controller.handleJoin("Bob", "session-2")
+
+        // Alice INFANTRY steht auf (3, 2), Versuch auf (3, 7) - viel zu weit.
+        val move = Move("Alice", UnitType.INFANTRY, 3, 2, 3, 7)
+        val state = controller.handleMove(move)
+
+        // Position unveraendert.
+        val infantry = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
+        assertEquals(3, infantry.x)
+        assertEquals(2, infantry.y)
+
+        // Turn switcht nicht.
+        assertEquals("Alice", state.currentTurn)
+    }
+
+    @Test
+    fun `move exactly 2 hex fields is accepted`() {
+        controller.handleJoin("Alice", "session-1")
+        controller.handleJoin("Bob", "session-2")
+
+        // (3, 2) -> (5, 2): genau 2 Hex weit, Ziel frei.
+        val move = Move("Alice", UnitType.INFANTRY, 3, 2, 5, 2)
+        val state = controller.handleMove(move)
+
+        val infantry = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
+        assertEquals(5, infantry.x)
+        assertEquals(2, infantry.y)
+
+        // Turn ist gewechselt.
+        assertEquals("Bob", state.currentTurn)
+    }
+
+    @Test
+    fun `move to same field is rejected`() {
+        controller.handleJoin("Alice", "session-1")
+        controller.handleJoin("Bob", "session-2")
+
+        // (3, 2) -> (3, 2): Distanz 0.
+        val move = Move("Alice", UnitType.INFANTRY, 3, 2, 3, 2)
+        val state = controller.handleMove(move)
+
+        assertEquals("Alice", state.currentTurn)
+    }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/HexDistanceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/HexDistanceTest.kt
@@ -1,0 +1,48 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class HexDistanceTest {
+
+    @Test
+    fun `distance to same cell is zero`() {
+        assertEquals(0, HexDistance.between(3, 3, 3, 3))
+    }
+
+    @Test
+    fun `distance to horizontal neighbor is one`() {
+        assertEquals(1, HexDistance.between(3, 3, 4, 3))
+        assertEquals(1, HexDistance.between(4, 3, 3, 3))
+    }
+
+    @Test
+    fun `distance to vertical neighbor is one`() {
+        assertEquals(1, HexDistance.between(3, 3, 3, 4))
+        assertEquals(1, HexDistance.between(3, 4, 3, 3))
+    }
+
+    @Test
+    fun `distance two horizontal hexes is two`() {
+        assertEquals(2, HexDistance.between(3, 3, 5, 3))
+    }
+
+    @Test
+    fun `distance three horizontal hexes is three`() {
+        assertEquals(3, HexDistance.between(3, 3, 6, 3))
+    }
+
+    @Test
+    fun `distance is symmetric`() {
+        val ab = HexDistance.between(2, 2, 5, 5)
+        val ba = HexDistance.between(5, 5, 2, 2)
+        assertEquals(ab, ba)
+    }
+
+    @Test
+    fun `distance from origin to far corner`() {
+        // 8x8 Grid: (0,0) -> (7,7) sollte > 2 sein
+        val distance = HexDistance.between(0, 0, 7, 7)
+        assertTrue(distance > 2, "Erwartet > 2, war $distance")
+    }
+}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/UnitTypeTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/UnitTypeTest.kt
@@ -183,6 +183,12 @@ class UnitTypeTest {
             it.player == "Bob" && it.type == UnitType.INFANTRY
         }
 
+        // Bobs INFANTRY in Reichweite von Alice platzieren - die Distanz-Regel
+        // (max 2 Hex) wuerde sonst greifen und den Combat-Test verhindern.
+        // (4,3) ist frei und Distanz 1 zu Alice INFANTRY auf (3,2).
+        bob.x = 4
+        bob.y = 3
+
         val move = Move("Alice", UnitType.INFANTRY, alice.x, alice.y, bob.x, bob.y)
         val state = gameService.handleMove(move)
 

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -72,19 +72,22 @@ class GameServiceTest {
         assertThat(bobAfter.x).isEqualTo(bobBefore.x)
         assertThat(bobAfter.y).isEqualTo(bobBefore.y)
 
-        // Alice gültiger Move → garantiert freies Feld
+        // Alice gültiger Move → nahes freies Feld (Distanz 1).
+        // Vorher wurde (0,0) verwendet, das ist mit der 2-Hex-Regel zu weit.
+        val aliceTargetX = aliceBefore.x
+        val aliceTargetY = aliceBefore.y + 1
         gameService.handleMove(
             Move("Alice", UnitType.INFANTRY,
                 aliceBefore.x, aliceBefore.y,
-                0, 0) //  garantiert frei
+                aliceTargetX, aliceTargetY)
         )
 
         val aliceAfter = gameService.getCurrentState().units.first {
             it.player == "Alice" && it.type == UnitType.INFANTRY
         }
 
-        assertThat(aliceAfter.x).isEqualTo(0)
-        assertThat(aliceAfter.y).isEqualTo(0)
+        assertThat(aliceAfter.x).isEqualTo(aliceTargetX)
+        assertThat(aliceAfter.y).isEqualTo(aliceTargetY)
 
         assertThat(gameService.getCurrentState().currentTurn).isEqualTo("Bob")
     }
@@ -150,6 +153,10 @@ class GameServiceTest {
         val aliceInfantry = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
         val bobCavalry    = state.units.first { it.player == "Bob"   && it.type == UnitType.CAVALRY  }
 
+        // Bobs CAVALRY in Reichweite platzieren (Distanz 1, freies Feld).
+        bobCavalry.x = aliceInfantry.x
+        bobCavalry.y = aliceInfantry.y + 1
+
         // INFANTRY beats CAVALRY → Alice gewinnt
         gameService.handleMove(Move(
             player = "Alice", type = UnitType.INFANTRY,
@@ -176,10 +183,11 @@ class GameServiceTest {
         state.units.removeIf { it.type == UnitType.BASE }
 
         val aliceArcher = state.units.first { it.player == "Alice" && it.type == UnitType.ARCHER }
+        // Move auf nahes leeres Feld (Distanz 1) - mit der 2-Hex-Regel ist (0,0) zu weit.
         gameService.handleMove(Move(
             player = "Alice", type = UnitType.ARCHER,
             fromX = aliceArcher.x, fromY = aliceArcher.y,
-            toX = 0, toY = 0
+            toX = aliceArcher.x, toY = aliceArcher.y + 1
         ))
 
         val updated = gameService.getCurrentState()
@@ -197,6 +205,10 @@ class GameServiceTest {
         val state = gameService.getCurrentState()
         val aliceInfantry = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
         val bobCavalry    = state.units.first { it.player == "Bob"   && it.type == UnitType.CAVALRY  }
+
+        // Bobs CAVALRY in Reichweite platzieren (Distanz 1, freies Feld).
+        bobCavalry.x = aliceInfantry.x
+        bobCavalry.y = aliceInfantry.y + 1
 
         // INFANTRY beats CAVALRY: Bob verliert CAVALRY, beide Basen stehen weiterhin
         gameService.handleMove(Move(
@@ -220,11 +232,12 @@ class GameServiceTest {
         val state = gameService.getCurrentState()
         val aliceArcher = state.units.first { it.player == "Alice" && it.type == UnitType.ARCHER }
 
-        // Move auf garantiert leeres Feld → kein Combat, kein Unit-Verlust, kein Win
+        // Move auf nahes leeres Feld - kein Combat, kein Unit-Verlust, kein Win.
+        // (0,0) waere ausserhalb der 2-Hex-Reichweite.
         gameService.handleMove(Move(
             player = "Alice", type = UnitType.ARCHER,
             fromX = aliceArcher.x, fromY = aliceArcher.y,
-            toX = 0, toY = 0
+            toX = aliceArcher.x, toY = aliceArcher.y + 1
         ))
 
         val updated = gameService.getCurrentState()
@@ -311,6 +324,11 @@ class GameServiceTest {
         val aliceInfantry = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
         val bobBase       = state.units.first { it.player == "Bob"   && it.type == UnitType.BASE }
 
+        // Bobs BASE in Reichweite verschieben (Distanz 1) - mit der 2-Hex-Regel
+        // ist die Originalposition (6,7) sonst nicht in einem Zug erreichbar.
+        bobBase.x = aliceInfantry.x
+        bobBase.y = aliceInfantry.y + 1
+
         // Alice zieht ihre INFANTRY direkt auf Bob's Basis-Hex - das beendet
         // das Spiel sofort, unabhaengig vom Stein-Schere-Papier-System.
         gameService.handleMove(Move(
@@ -359,6 +377,10 @@ class GameServiceTest {
 
         val aliceInfantry = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
         val bobCavalry    = state.units.first { it.player == "Bob"   && it.type == UnitType.CAVALRY }
+
+        // Bobs CAVALRY in Reichweite platzieren (Distanz 1, freies Feld).
+        bobCavalry.x = aliceInfantry.x
+        bobCavalry.y = aliceInfantry.y + 1
 
         // Alice greift Bob's CAVALRY an. INFANTRY beats CAVALRY,
         // Bob verliert seine einzige regulaere Unit - hat aber noch Basis.


### PR DESCRIPTION
Bewegung wird auf maximal 2 Hex-Felder pro Zug beschränkt.

- `HexDistance`: Neue Utility-Klasse für Distanz-Berechnung in 
  odd-q offset Koordinaten (kompatibel mit Frontend HexGridLogic)
- `GameService.handleMove`: Lehnt Moves mit Distanz > 2 oder = 0 ab
- `MAX_MOVE_DISTANCE = 2` als Konstante
- Unit-Tests für HexDistance (7 Cases)
- Integration-Tests für Move-Validierung (3 Cases)

PR berührt 6 Dateien (über dem üblichen 4-Datei-Limit). Jede Änderung 
ist direkt von der Akzeptanzkriterien abgeleitet — keine unrelated 
Refactorings. Die Test-Anpassungen sind forciert durch die neue 
Validierung, weil bestehende Tests "unrealistisch weite" Moves nutzten.


## Test plan
- [x] Move > 2 Hex wird abgelehnt
- [x] Move = 2 Hex wird akzeptiert (Grenze inklusiv)
- [x] Move = 0 Hex (Stand) wird abgelehnt
- [x] HexDistance ist symmetrisch
- [x] Bestehende Tests grün
