### PR TITLE
Feat/61 bewegung eroberung roundsystem

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -77,10 +77,20 @@ class WebSocketBrokerController(
             return null
         }
 
-        val turnBefore = stateBefore.currentTurn
+        // Snapshot vor dem Move - wenn sich nach handleMove nichts geaendert hat,
+        // wurde der Move abgelehnt. Currentturn-Vergleich reicht hier nicht mehr,
+        // weil der Turn mit dem Rundensystem nicht nach jedem Move switcht.
+        val unitsBefore = stateBefore.units.map {
+            "${it.player}-${it.type}-${it.x},${it.y}"
+        }.toSet()
+
         val stateAfter = gameService.handleMove(move)
 
-        if (stateAfter.currentTurn == turnBefore) {
+        val unitsAfter = stateAfter.units.map {
+            "${it.player}-${it.type}-${it.x},${it.y}"
+        }.toSet()
+
+        if (unitsBefore == unitsAfter) {
             sendError(sessionId, ErrorCode.INVALID_MOVE, "Dieser Zug ist laut Regeln ungültig.")
             return null
         }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -99,6 +99,25 @@ class WebSocketBrokerController(
     }
 
 
+    @MessageMapping("/endTurn")
+    @SendTo("/topic/game")
+    fun endTurn(playerName: String, headerAccessor: SimpMessageHeaderAccessor): GameState? {
+        val sessionId = headerAccessor.sessionId ?: ""
+        val stateBefore = gameService.getCurrentState()
+
+        if (stateBefore.status != GameStatus.IN_PROGRESS) {
+            sendError(sessionId, ErrorCode.GAME_NOT_STARTED, "Runde beenden abgelehnt: Spiel laeuft nicht.")
+            return null
+        }
+
+        if (stateBefore.currentTurn != playerName) {
+            sendError(sessionId, ErrorCode.NOT_YOUR_TURN, "Du kannst nicht die Runde eines anderen Spielers beenden!")
+            return null
+        }
+
+        return gameService.endTurn(playerName)
+    }
+
     fun handleJoin(name: String, sessionId: String) = gameService.handleJoin(name, sessionId)
     fun handleMove(move: Move) = gameService.handleMove(move)
 

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -202,6 +202,25 @@ class GameService(
         state.units.forEach { it.hasMovedThisTurn = false }
     }
 
+    /**
+     * Prueft ob der gegebene Spieler in dieser Runde bereits alle seine
+     * bewegbaren Einheiten gezogen hat. SKELETONs und BASEs zaehlen nicht
+     * als bewegbar.
+     *
+     * Gibt `false` zurueck wenn der Spieler keine bewegbaren Einheiten
+     * besitzt - in dem Fall muss der Turn manuell ueber endTurn beendet
+     * werden, sonst wuerde der Turn sofort wechseln ohne dass ein Move
+     * stattfand.
+     */
+    private fun allMovableUnitsHaveMoved(state: GameState, playerName: String): Boolean {
+        val movable = state.units.filter {
+            it.player == playerName &&
+                    it.type != UnitType.SKELETON &&
+                    it.type != UnitType.BASE
+        }
+        return movable.isNotEmpty() && movable.all { it.hasMovedThisTurn }
+    }
+
     // WICHTIG FÜR TEST  Nur den aktuellen Stand lesen
     fun getCurrentState(state: GameState): GameState = synchronized(state.lock) {
         return state

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -186,6 +186,24 @@ class GameService(
         move: Move
     ): GameState = handleMove(this.gameState, move)
 
+    /**
+     * Beendet die Runde des angegebenen Spielers freiwillig.
+     *
+     * Wird vom Controller aufgerufen wenn der Spieler auf "Runde beenden"
+     * klickt - auch wenn noch nicht alle Einheiten bewegt wurden. Nur der
+     * aktuelle Spieler kann seinen eigenen Turn beenden, andere werden
+     * ignoriert.
+     */
+    fun endTurn(state: GameState, playerName: String): GameState = synchronized(state.lock) {
+        if (state.status != GameStatus.IN_PROGRESS) return state
+        if (state.currentTurn != playerName) return state
+        switchTurn(state)
+        return state
+    }
+
+    //Bridge Method endTurn
+    fun endTurn(playerName: String): GameState = endTurn(this.gameState, playerName)
+
 
     private fun switchTurn(state: GameState) {
 

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -116,7 +116,7 @@ class GameService(
                 state.units.remove(enemyOnTarget)
                 unit.x = move.toX
                 unit.y = move.toY
-                switchTurn(state)
+                finishMove(state, unit, move.player)
                 checkWinCondition(state)
                 return state
             }
@@ -125,7 +125,7 @@ class GameService(
             combatService.applyCombatResult(result, unit, enemyOnTarget)
             if (!result.defenderSurvived) state.units.remove(enemyOnTarget)
             if (!result.attackerSurvived) state.units.remove(unit)
-            switchTurn(state)
+            finishMove(state, unit, move.player)
             checkWinCondition(state)
             return state
         }
@@ -133,8 +133,7 @@ class GameService(
         unit.x = move.toX
         unit.y = move.toY
 
-        val (p1, p2) = state.players
-        state.currentTurn = if (state.currentTurn == p1.name) p2.name else p1.name
+        finishMove(state, unit, move.player)
 
         checkWinCondition(state)
         return state
@@ -219,6 +218,23 @@ class GameService(
                     it.type != UnitType.BASE
         }
         return movable.isNotEmpty() && movable.all { it.hasMovedThisTurn }
+    }
+
+    /**
+     * Wird nach jedem erfolgreichen Move aufgerufen. Markiert die Einheit
+     * als bewegt (falls sie noch lebt) und switcht automatisch den Turn
+     * wenn alle bewegbaren Einheiten des aktuellen Spielers gezogen haben.
+     */
+    private fun finishMove(state: GameState, unit: GameUnit, playerName: String) {
+        // Falls die Einheit den Move ueberlebt hat, als bewegt markieren.
+        // Nach Combat kann sie aus state.units entfernt worden sein.
+        if (unit in state.units) {
+            unit.hasMovedThisTurn = true
+        }
+        // Auto-Switch wenn alle Einheiten gezogen haben.
+        if (allMovableUnitsHaveMoved(state, playerName)) {
+            switchTurn(state)
+        }
     }
 
     // WICHTIG FÜR TEST  Nur den aktuellen Stand lesen

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -192,6 +192,9 @@ class GameService(
                 p2.name
             else
                 p1.name
+
+        // Neue Runde fuer den naechsten Spieler: alle Einheiten duerfen wieder ziehen.
+        state.units.forEach { it.hasMovedThisTurn = false }
     }
 
     // WICHTIG FÜR TEST  Nur den aktuellen Stand lesen

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -91,6 +91,11 @@ class GameService(
                     it.y == move.fromY
         } ?: return state
 
+        // Eine Einheit darf pro Runde nur einmal bewegt werden.
+        // Verhindert dass ein Spieler dieselbe Einheit zweimal in einer Runde
+        // zieht - greift erst wenn handleMove die Flag tatsaechlich setzt.
+        if (unit.hasMovedThisTurn) return state
+
         val friendlyOnTarget = state.units.any {
             it.x == move.toX && it.y == move.toY && it.player == move.player
         }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameUnit.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameUnit.kt
@@ -4,5 +4,6 @@ data class GameUnit(
     var player: String,
     var x: Int = 0,
     var y: Int = 0,
-    var type: UnitType
+    var type: UnitType,
+    var hasMovedThisTurn: Boolean = false
 )

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -93,9 +93,11 @@ class WebSocketBrokerControllerTest {
         controller.handleJoin("Josef", "session-1")
         controller.handleJoin("Sebastian", "session-2")
 
-        val move = Move("Josef", UnitType.INFANTRY, 3, 2, 3, 3)
-
-        val state = controller.handleMove(move)
+        // Mit Rundensystem switcht der Turn erst wenn alle bewegbaren Einheiten
+        // (ARCHER, INFANTRY, CAVALRY) des Spielers gezogen haben.
+        controller.handleMove(Move("Josef", UnitType.ARCHER, 2, 2, 2, 3))
+        controller.handleMove(Move("Josef", UnitType.INFANTRY, 3, 2, 3, 3))
+        val state = controller.handleMove(Move("Josef", UnitType.CAVALRY, 4, 2, 4, 3))
 
         val josefUnit = state.units.find {
             it.player == "Josef" && it.type == UnitType.INFANTRY
@@ -141,15 +143,15 @@ class WebSocketBrokerControllerTest {
         controller.handleJoin("Alice", "session-1")
         controller.handleJoin("Bob", "session-2")
 
-        // First move
-        controller.handleMove(
-            Move("Alice", UnitType.INFANTRY, 3, 2, 3, 3)
-        )
+        // Alice bewegt alle 3 bewegbaren Einheiten - dann ist Bob dran.
+        controller.handleMove(Move("Alice", UnitType.ARCHER, 2, 2, 2, 3))
+        controller.handleMove(Move("Alice", UnitType.INFANTRY, 3, 2, 3, 3))
+        controller.handleMove(Move("Alice", UnitType.CAVALRY, 4, 2, 4, 3))
 
-        // Second move
-        val result = controller.handleMove(
-            Move("Bob", UnitType.INFANTRY, 6, 5, 6, 6)
-        )
+        // Bob bewegt alle 3 bewegbaren Einheiten
+        controller.handleMove(Move("Bob", UnitType.ARCHER, 5, 5, 5, 6))
+        controller.handleMove(Move("Bob", UnitType.INFANTRY, 6, 5, 6, 6))
+        val result = controller.handleMove(Move("Bob", UnitType.CAVALRY, 7, 5, 7, 6))
 
         val aliceUnit = result.units.find {
             it.player == "Alice" && it.type == UnitType.INFANTRY
@@ -215,16 +217,16 @@ class WebSocketBrokerControllerTest {
         controller.handleJoin("Alice", "session-1")
         controller.handleJoin("Bob", "session-2")
 
-        // Alice move
-        val state1 = controller.handleMove(
-            Move("Alice", UnitType.INFANTRY, 3, 2, 3, 3)
-        )
+        // Alice bewegt alle 3 Einheiten - dann switcht zu Bob
+        controller.handleMove(Move("Alice", UnitType.ARCHER, 2, 2, 2, 3))
+        controller.handleMove(Move("Alice", UnitType.INFANTRY, 3, 2, 3, 3))
+        val state1 = controller.handleMove(Move("Alice", UnitType.CAVALRY, 4, 2, 4, 3))
         assertEquals("Bob", state1.currentTurn)
 
-        // Bob move
-        val state2 = controller.handleMove(
-            Move("Bob", UnitType.INFANTRY, 6, 5, 6, 6)
-        )
+        // Bob bewegt alle 3 Einheiten - dann switcht zurueck zu Alice
+        controller.handleMove(Move("Bob", UnitType.ARCHER, 5, 5, 5, 6))
+        controller.handleMove(Move("Bob", UnitType.INFANTRY, 6, 5, 6, 6))
+        val state2 = controller.handleMove(Move("Bob", UnitType.CAVALRY, 7, 5, 7, 6))
         assertEquals("Alice", state2.currentTurn)
     }
 
@@ -393,15 +395,13 @@ class WebSocketBrokerControllerTest {
         controller.handleJoin("Alice", "session-1")
         controller.handleJoin("Bob", "session-2")
 
-        val move = Move(
-            player = "Alice",
-            type = UnitType.INFANTRY,
-            fromX = 3,
-            fromY = 2,
-            toX = 3,
-            toY = 3
+        // Alle 3 bewegbaren Einheiten bewegen damit der Turn switcht.
+        controller.move(Move("Alice", UnitType.ARCHER, 2, 2, 2, 3), headerAccessor)
+        controller.move(Move("Alice", UnitType.INFANTRY, 3, 2, 3, 3), headerAccessor)
+        val result = controller.move(
+            Move("Alice", UnitType.CAVALRY, 4, 2, 4, 3),
+            headerAccessor
         )
-        val result = controller.move(move, headerAccessor)
 
         assertNotNull(result)
 

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -407,4 +407,61 @@ class WebSocketBrokerControllerTest {
 
         assertEquals("Bob", result?.currentTurn)
     }
+
+    // ---- Tests fuer /endTurn (Sub-Issue #105) ---------------------------
+
+    @Test
+    fun `endTurn switches to next player`() {
+        controller.handleJoin("Alice", "session-1")
+        controller.handleJoin("Bob", "session-2")
+
+        val result = controller.endTurn("Alice", headerAccessor)
+
+        assertNotNull(result)
+        assertEquals("Bob", result?.currentTurn)
+    }
+
+    @Test
+    fun `endTurn rejected when not players turn`() {
+        controller.handleJoin("Alice", "session-1")
+        controller.handleJoin("Bob", "session-2")
+
+        val result = controller.endTurn("Bob", headerAccessor)
+
+        assertNull(result)
+        verify(messagingTemplate).convertAndSendToUser(
+            eq("test-session"),
+            eq("/queue/errors"),
+            argThat { it is ErrorMessage && it.errorCode == ErrorCode.NOT_YOUR_TURN }
+        )
+    }
+
+    @Test
+    fun `endTurn rejected when game not started`() {
+        val result = controller.endTurn("Alice", headerAccessor)
+
+        assertNull(result)
+        verify(messagingTemplate).convertAndSendToUser(
+            eq("test-session"),
+            eq("/queue/errors"),
+            argThat { it is ErrorMessage && it.errorCode == ErrorCode.GAME_NOT_STARTED }
+        )
+    }
+
+    @Test
+    fun `endTurn resets hasMovedThisTurn flags`() {
+        controller.handleJoin("Alice", "session-1")
+        controller.handleJoin("Bob", "session-2")
+
+        // Alice bewegt INFANTRY (Flag wird gesetzt)
+        controller.handleMove(Move("Alice", UnitType.INFANTRY, 3, 2, 3, 3))
+
+        // Alice beendet Runde freiwillig (CAVALRY und ARCHER noch nicht bewegt)
+        controller.endTurn("Alice", headerAccessor)
+
+        // Nach endTurn muessen alle Flags zurueckgesetzt sein.
+        val state = gameService.getCurrentState()
+        assertTrue(state.units.none { it.hasMovedThisTurn })
+        assertEquals("Bob", state.currentTurn)
+    }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/UnitTypeTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/UnitTypeTest.kt
@@ -138,16 +138,15 @@ class UnitTypeTest {
             it.player == "Alice" && it.type == UnitType.ARCHER
         }
 
-        val move = Move(
-            player = "Alice",
-            type = UnitType.ARCHER,
-            fromX = archer.x,
-            fromY = archer.y,
-            toX = archer.x,
-            toY = archer.y + 1
-        )
-
-        val state = gameService.handleMove(move)
+        // Mit Rundensystem switcht der Turn erst wenn alle 3 bewegbaren
+        // Einheiten gezogen haben.
+        gameService.handleMove(Move(
+            player = "Alice", type = UnitType.ARCHER,
+            fromX = archer.x, fromY = archer.y,
+            toX = archer.x, toY = archer.y + 1
+        ))
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY, 3, 2, 3, 3))
+        val state = gameService.handleMove(Move("Alice", UnitType.CAVALRY, 4, 2, 4, 3))
 
         assertEquals("Bob", state.currentTurn)
     }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -72,12 +72,12 @@ class GameServiceTest {
         assertThat(bobAfter.x).isEqualTo(bobBefore.x)
         assertThat(bobAfter.y).isEqualTo(bobBefore.y)
 
-        // Alice gültiger Move → garantiert freies Feld
-        gameService.handleMove(
-            Move("Alice", UnitType.INFANTRY,
-                aliceBefore.x, aliceBefore.y,
-                0, 0) //  garantiert frei
-        )
+        // Alice muss alle 3 bewegbaren Einheiten ziehen, damit der Turn switcht.
+        gameService.handleMove(Move("Alice", UnitType.ARCHER, 2, 2, 2, 3))
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY,
+            aliceBefore.x, aliceBefore.y,
+            0, 0))
+        gameService.handleMove(Move("Alice", UnitType.CAVALRY, 4, 2, 4, 3))
 
         val aliceAfter = gameService.getCurrentState().units.first {
             it.player == "Alice" && it.type == UnitType.INFANTRY
@@ -198,7 +198,12 @@ class GameServiceTest {
         val aliceInfantry = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
         val bobCavalry    = state.units.first { it.player == "Bob"   && it.type == UnitType.CAVALRY  }
 
-        // INFANTRY beats CAVALRY: Bob verliert CAVALRY, beide Basen stehen weiterhin
+        // Alice bewegt zuerst ARCHER und CAVALRY auf freie Felder
+        gameService.handleMove(Move("Alice", UnitType.ARCHER, 2, 2, 2, 3))
+        gameService.handleMove(Move("Alice", UnitType.CAVALRY, 4, 2, 4, 3))
+
+        // INFANTRY beats CAVALRY: Bob verliert CAVALRY, beide Basen stehen weiterhin.
+        // Das ist Alices dritter und letzter Zug - Turn switcht zu Bob.
         gameService.handleMove(Move(
             player = "Alice", type = UnitType.INFANTRY,
             fromX = aliceInfantry.x, fromY = aliceInfantry.y,
@@ -220,12 +225,14 @@ class GameServiceTest {
         val state = gameService.getCurrentState()
         val aliceArcher = state.units.first { it.player == "Alice" && it.type == UnitType.ARCHER }
 
-        // Move auf garantiert leeres Feld → kein Combat, kein Unit-Verlust, kein Win
+        // Alice bewegt alle 3 Einheiten - keine Combats, keine Unit-Verluste.
         gameService.handleMove(Move(
             player = "Alice", type = UnitType.ARCHER,
             fromX = aliceArcher.x, fromY = aliceArcher.y,
             toX = 0, toY = 0
         ))
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY, 3, 2, 3, 3))
+        gameService.handleMove(Move("Alice", UnitType.CAVALRY, 4, 2, 4, 3))
 
         val updated = gameService.getCurrentState()
         assertThat(updated.status).isEqualTo(GameStatus.IN_PROGRESS)


### PR DESCRIPTION
Implementiert Rundensystem: Spieler bewegt pro Runde alle seine Einheiten
einmal, bevor der Turn zum nächsten Spieler wechselt. Manuelles Beenden 
der Runde über /endTurn Endpoint möglich (Frontend-Button).