### PR TITLE
Implement room-specific disconnect handling (#84)

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandler.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandler.kt
@@ -8,6 +8,7 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent
 @Component
 class DisconnectHandler(
     private val gameService: GameService,
+    private val roomRegistry: RoomRegistry,
     private val messagingTemplate: SimpMessagingTemplate
 ) {
 
@@ -16,12 +17,18 @@ class DisconnectHandler(
         val sessionId = event.sessionId
         println("DisconnectHandler: Session $sessionId disconnected")
 
+        val room = roomRegistry.getAllRooms()
+            .find { room ->
+                room.gameState.players.any {
+                    it.sessionId == sessionId
+                }
+            } ?: return
+
         val playerExists = gameService.gameState.players.any { it.sessionId == sessionId }
 
-        val updatedState = gameService.handleDisconnect(sessionId)
+        val updatedState = gameService.handleDisconnect(room.gameState, sessionId)
 
-        if (playerExists) {
-            messagingTemplate.convertAndSend("/topic/game", updatedState)
-        }
+        messagingTemplate.convertAndSend("/topic/rooms/${room.roomId}/state",
+            updatedState)
     }
 }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandler.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandler.kt
@@ -5,6 +5,13 @@ import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Component
 import org.springframework.web.socket.messaging.SessionDisconnectEvent
 
+/**
+ * Handles WebSocket disconnect events.
+ *
+ * When a client disconnects, the handler locates the affected room,
+ * removes the corresponding player from that room and broadcasts the
+ * updated game state to subscribers of the room-specific topic.
+ */
 @Component
 class DisconnectHandler(
     private val gameService: GameService,
@@ -12,6 +19,15 @@ class DisconnectHandler(
     private val messagingTemplate: SimpMessagingTemplate
 ) {
 
+    /**
+     * Processes a WebSocket disconnect event.
+     *
+     * The disconnected player is removed only from the room they belong to.
+     * The updated room state is then broadcast to all subscribers of the
+     * corresponding room topic.
+     *
+     * @param event The Spring WebSocket disconnect event.
+     */
     @EventListener
     fun handleDisconnect(event: SessionDisconnectEvent) {
         val sessionId = event.sessionId
@@ -23,8 +39,6 @@ class DisconnectHandler(
                     it.sessionId == sessionId
                 }
             } ?: return
-
-        val playerExists = gameService.gameState.players.any { it.sessionId == sessionId }
 
         val updatedState = gameService.handleDisconnect(room.gameState, sessionId)
 

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerComponentTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerComponentTest.kt
@@ -163,4 +163,65 @@ class DisconnectHandlerComponentTest {
         )
     }
 
+    @Test
+    fun `disconnect sets only affected room to FINISHED`() {
+
+        val room1 = roomRegistry.createRoom(
+            GameMode.DUAL_VALLEY
+        )
+
+        val room2 = roomRegistry.createRoom(
+            GameMode.DUAL_VALLEY
+        )
+
+        gameService.handleJoin(
+            room1.gameState,
+            "Alice",
+            "session-1"
+        )
+
+        gameService.handleJoin(
+            room1.gameState,
+            "Bob",
+            "session-2"
+        )
+
+        gameService.handleJoin(
+            room2.gameState,
+            "Charlie",
+            "session-3"
+        )
+
+        gameService.handleJoin(
+            room2.gameState,
+            "Dave",
+            "session-4"
+        )
+
+        assertEquals(
+            GameStatus.IN_PROGRESS,
+            room1.gameState.status
+        )
+
+        assertEquals(
+            GameStatus.IN_PROGRESS,
+            room2.gameState.status
+        )
+
+        gameService.handleDisconnect(
+            room2.gameState,
+            "session-3"
+        )
+
+        assertEquals(
+            GameStatus.IN_PROGRESS,
+            room1.gameState.status
+        )
+
+        assertEquals(
+            GameStatus.FINISHED,
+            room2.gameState.status
+        )
+    }
+
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerComponentTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerComponentTest.kt
@@ -1,5 +1,6 @@
 package at.aau.hexabrawl.websocketserver.model
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
@@ -9,13 +10,28 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent
 class DisconnectHandlerComponentTest {
 
     private val gameService = GameService(CombatService())
+    private val roomRegistry = RoomRegistry()
     private val messagingTemplate = Mockito.mock(SimpMessagingTemplate::class.java)
-    private val handler = DisconnectHandler(gameService, messagingTemplate)
+    private val handler = DisconnectHandler(gameService, roomRegistry, messagingTemplate)
 
     @Test
     fun `handleDisconnect broadcasts updated state`() {
-        gameService.handleJoin("Alice", "session-1")
-        gameService.handleJoin("Bob", "session-2")
+
+        val room = roomRegistry.createRoom(
+            GameMode.DUAL_VALLEY
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "Alice",
+            "session-1"
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "Bob",
+            "session-2"
+        )
 
         val event = Mockito.mock(SessionDisconnectEvent::class.java)
         Mockito.`when`(event.sessionId).thenReturn("session-1")
@@ -23,21 +39,26 @@ class DisconnectHandlerComponentTest {
         handler.handleDisconnect(event)
 
         Mockito.verify(messagingTemplate).convertAndSend(
-            ArgumentMatchers.eq("/topic/game"),
+            ArgumentMatchers.eq("/topic/rooms/${room.roomId}/state"),
             ArgumentMatchers.any(GameState::class.java)
         )
     }
 
     @Test
     fun `handleDisconnect removes player from game`() {
-        gameService.handleJoin("Alice", "session-1")
+
+        val room = roomRegistry.createRoom(
+            GameMode.DUAL_VALLEY
+        )
+
+        gameService.handleJoin(room.gameState,"Alice", "session-1")
 
         val event = Mockito.mock(SessionDisconnectEvent::class.java)
         Mockito.`when`(event.sessionId).thenReturn("session-1")
 
         handler.handleDisconnect(event)
 
-        assert(gameService.gameState.players.isEmpty())
+        assertEquals(0, room.gameState.players.size)
     }
 
     @Test
@@ -48,6 +69,98 @@ class DisconnectHandlerComponentTest {
         handler.handleDisconnect(event)
 
         Mockito.verifyNoInteractions(messagingTemplate)
+    }
+
+    @Test
+    fun `disconnect removes player only from affected room`() {
+
+        val room1 = roomRegistry.createRoom(
+            GameMode.DUAL_VALLEY
+        )
+
+        val room2 = roomRegistry.createRoom(
+            GameMode.DUAL_VALLEY
+        )
+
+        gameService.handleJoin(
+            room1.gameState,
+            "Alice",
+            "session-1"
+        )
+
+        gameService.handleJoin(
+            room1.gameState,
+            "Bob",
+            "session-2"
+        )
+
+        gameService.handleJoin(
+            room2.gameState,
+            "Charlie",
+            "session-3"
+        )
+
+        gameService.handleJoin(
+            room2.gameState,
+            "Dave",
+            "session-4"
+        )
+
+        val event = Mockito.mock(SessionDisconnectEvent::class.java)
+
+        Mockito.`when`(event.sessionId)
+            .thenReturn("session-3")
+
+        handler.handleDisconnect(event)
+
+        assertEquals(
+            2,
+            room1.gameState.players.size
+        )
+
+        assertEquals(
+            1,
+            room2.gameState.players.size
+        )
+
+        assertEquals(
+            "Dave",
+            room2.gameState.players.first().name
+        )
+    }
+
+    @Test
+    fun `handleDisconnect broadcasts to room specific topic`() {
+
+        val room = roomRegistry.createRoom(
+            GameMode.DUAL_VALLEY
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "Alice",
+            "session-1"
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "Bob",
+            "session-2"
+        )
+
+        val event = Mockito.mock(SessionDisconnectEvent::class.java)
+
+        Mockito.`when`(event.sessionId)
+            .thenReturn("session-1")
+
+        handler.handleDisconnect(event)
+
+        Mockito.verify(messagingTemplate).convertAndSend(
+            ArgumentMatchers.eq(
+                "/topic/rooms/${room.roomId}/state"
+            ),
+            ArgumentMatchers.any(GameState::class.java)
+        )
     }
 
 }


### PR DESCRIPTION
## Summary

Implements room-specific disconnect handling as part of the Multisession Management feature (#51).

### Changes

* Added room-aware disconnect handling using `RoomRegistry`
* Disconnects now affect only the room of the disconnected player
* Updated broadcasts to use room-specific topics
* Prevented disconnects from affecting unrelated rooms
* Added tests for room-specific disconnect behavior
* Added tests verifying room status transitions to `FINISHED`
* Added KDocs for disconnect handling

### Acceptance Criteria

* [x] Disconnect removes player only from their room
* [x] Other players in the room are informed via broadcast
* [x] Other rooms are not affected
* [x] Room status is correctly set to `FINISHED`
* [x] Thread-safe implementation
* [x] KDocs present
* [x] Unit tests present

### Technical Notes

Thread safety is ensured by:

* `ConcurrentHashMap` in `RoomRegistry`
* `synchronized(state.lock)` in `GameService`

Broadcast destination changed from:

```text
/topic/game
```

to:

```text
/topic/rooms/{roomId}/state
```

### Testing

All tests pass successfully.

Coverage remains above project requirements and includes dedicated tests for room-specific disconnect handling.
