### PR TITLE
Feat/61 bewegung eroberung field ownership

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Field.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Field.kt
@@ -1,0 +1,18 @@
+package at.aau.hexabrawl.websocketserver.model
+
+/**
+ * Repraesentiert ein einzelnes Hex-Feld auf dem Spielbrett.
+ *
+ * Felder gehoeren entweder einem Spieler (durch Eroberung oder als
+ * Startgebiet) oder sind neutral (owner = null). Die Position (x, y)
+ * verwendet die gleichen "odd-q offset" Koordinaten wie die Einheiten
+ * im GameState.
+ *
+ * `owner` ist mutable damit Felder durch Eroberung den Besitzer
+ * wechseln koennen (siehe Folge-Sub-Issue #104).
+ */
+data class Field(
+    val x: Int,
+    val y: Int,
+    var owner: String? = null
+)

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -230,6 +230,35 @@ class GameService(
     fun endTurn(playerName: String): GameState = endTurn(this.gameState, playerName)
 
 
+    /**
+     * Erzeugt alle Felder des Boards und weist die Startgebiete an die
+     * beiden Spieler zu. Vor dem Aufruf muessen beide Spieler in
+     * state.players existieren.
+     *
+     * Wird beim Spielstart und nach jedem Reset aufgerufen.
+     */
+    private fun initializeBoard(state: GameState) {
+        state.fields.clear()
+
+        // Alle Felder erzeugen, default neutral (owner = null).
+        for (x in 0 until BOARD_COLS) {
+            for (y in 0 until BOARD_ROWS) {
+                state.fields.add(Field(x, y))
+            }
+        }
+
+        // Startgebiete den Spielern zuweisen.
+        val p1 = state.players[0]
+        val p2 = state.players[1]
+
+        START_TERRITORY_P1.forEach { (x, y) ->
+            state.fields.first { it.x == x && it.y == y }.owner = p1.name
+        }
+        START_TERRITORY_P2.forEach { (x, y) ->
+            state.fields.first { it.x == x && it.y == y }.owner = p2.name
+        }
+    }
+
     private fun switchTurn(state: GameState) {
 
         val (p1, p2) = state.players

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -22,6 +22,22 @@ class GameService(
         // legitime Moves der bestehenden Test-Suite.
         val BASE_POSITION_P1: Pair<Int, Int> = Pair(3, 0)
         val BASE_POSITION_P2: Pair<Int, Int> = Pair(6, 7)
+
+        // Board-Dimensionen fuer DUAL_VALLEY (Standard-Modus).
+        // Wird spaeter durch GameMode-spezifische Werte ersetzt sobald
+        // der Multisession-PR gemergt ist.
+        const val BOARD_ROWS = 10
+        const val BOARD_COLS = 10
+
+        // Startgebiete pro Spieler: Felder unter den Start-Einheiten + Basis.
+        val START_TERRITORY_P1: List<Pair<Int, Int>> = listOf(
+            2 to 2, 3 to 2, 4 to 2,  // ARCHER, INFANTRY, CAVALRY
+            3 to 0                    // BASE
+        )
+        val START_TERRITORY_P2: List<Pair<Int, Int>> = listOf(
+            5 to 5, 6 to 5, 7 to 5,
+            6 to 7
+        )
     }
 
     fun handleJoin(state: GameState, playerName: String, sessionId:String=""): GameState = synchronized(state.lock) {

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -82,6 +82,8 @@ class GameService(
             state.units.add(GameUnit(p1.name, BASE_POSITION_P1.first, BASE_POSITION_P1.second, UnitType.BASE))
             state.units.add(GameUnit(p2.name, BASE_POSITION_P2.first, BASE_POSITION_P2.second, UnitType.BASE))
 
+            initializeBoard(state)
+
             state.currentTurn = p1.name
             state.status = GameStatus.IN_PROGRESS
             println("Service: GAME STARTED")

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -326,6 +326,7 @@ class GameService(
     fun initializeGame(state: GameState): GameState = synchronized(state.lock) {
         state.players.clear()
         state.units.clear()
+        state.fields.clear()
         state.currentTurn = null
         state.status = GameStatus.WAITING_FOR_PLAYERS
         println("Service: GAME INITIALIZED - Everything cleared")
@@ -361,6 +362,14 @@ class GameService(
             // Basis pro Spieler an der vordefinierten Position wiederherstellen
             val basePos = if (index == 0) BASE_POSITION_P1 else BASE_POSITION_P2
             state.units.add(GameUnit(player.name, basePos.first, basePos.second, UnitType.BASE))
+        }
+
+        // Board mit Startgebieten neu initialisieren - aber nur wenn beide
+        // Spieler da sind, sonst greift initializeBoard auf state.players[1] zu.
+        if (state.players.size == MAX_PLAYERS) {
+            initializeBoard(state)
+        } else {
+            state.fields.clear()
         }
 
         state.currentTurn = state.players.firstOrNull()?.name

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameState.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameState.kt
@@ -10,6 +10,7 @@ enum class GameStatus {
 data class GameState(
     val players: MutableList<Player> = mutableListOf(),
     val units: MutableList<GameUnit> = mutableListOf(),
+    val fields: MutableList<Field> = mutableListOf(),
     var currentTurn: String? = null,
     var status: GameStatus = GameStatus.WAITING_FOR_PLAYERS,
     var winner: String? = null

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldTest.kt
@@ -1,0 +1,105 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class FieldTest {
+
+    private lateinit var gameService: GameService
+
+    @BeforeEach
+    fun setup() {
+        gameService = GameService(CombatService())
+    }
+
+    @Test
+    fun `all board fields are created on game start`() {
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+        val state = gameService.getCurrentState()
+
+        // 10x10 = 100 Felder
+        assertEquals(100, state.fields.size)
+    }
+
+    @Test
+    fun `Alice has starting territory`() {
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+        val state = gameService.getCurrentState()
+
+        val aliceFields = state.fields.filter { it.owner == "Alice" }
+        assertEquals(4, aliceFields.size)  // 3 Einheiten + 1 Basis
+    }
+
+    @Test
+    fun `Bob has starting territory`() {
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+        val state = gameService.getCurrentState()
+
+        val bobFields = state.fields.filter { it.owner == "Bob" }
+        assertEquals(4, bobFields.size)
+    }
+
+    @Test
+    fun `most fields are neutral on game start`() {
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+        val state = gameService.getCurrentState()
+
+        val neutralFields = state.fields.filter { it.owner == null }
+        assertEquals(100 - 8, neutralFields.size)  // 92 neutral
+    }
+
+    @Test
+    fun `Alice and Bob have non-overlapping territories`() {
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+        val state = gameService.getCurrentState()
+
+        val alicePositions = state.fields.filter { it.owner == "Alice" }
+            .map { it.x to it.y }.toSet()
+        val bobPositions = state.fields.filter { it.owner == "Bob" }
+            .map { it.x to it.y }.toSet()
+
+        assertTrue(alicePositions.intersect(bobPositions).isEmpty())
+    }
+
+    @Test
+    fun `initializeGame clears all fields`() {
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+        gameService.initializeGame()
+
+        assertTrue(gameService.getCurrentState().fields.isEmpty())
+    }
+
+    @Test
+    fun `resetToStartCondition re-initializes board`() {
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+        gameService.resetToStartCondition()
+
+        val state = gameService.getCurrentState()
+        assertEquals(100, state.fields.size)
+        assertEquals(4, state.fields.count { it.owner == "Alice" })
+        assertEquals(4, state.fields.count { it.owner == "Bob" })
+    }
+
+    @Test
+    fun `fields have correct coordinates`() {
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+        val state = gameService.getCurrentState()
+
+        // Sanity check: jedes (x,y) im Raster existiert genau einmal
+        for (x in 0 until GameService.BOARD_COLS) {
+            for (y in 0 until GameService.BOARD_ROWS) {
+                val count = state.fields.count { it.x == x && it.y == y }
+                assertEquals(1, count, "Feld ($x,$y) sollte genau einmal existieren")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Datenmodell für Field-Ownership eingeführt: jedes Hex-Feld auf dem Board 
kann einem Spieler gehören oder neutral sein. Beim Spielstart wird das 
komplette Board (10×10) erzeugt und Startgebiete an die beiden Spieler 
verteilt. Foundation für die Eroberungslogik (#104).

## Changes

### Backend
- **`Field`**: Neue Data Class mit `(x, y, owner: String?)` 
- **`GameState.fields`**: Liste aller Board-Felder
- **`GameService.initializeBoard`**: Erzeugt alle Felder und weist Startgebiete zu
- **Konstanten:**
  - `BOARD_ROWS`/`BOARD_COLS` = 10 (DUAL_VALLEY)
  - `START_TERRITORY_P1`/`P2` = je 4 Felder
- **`initializeGame`**: löscht Felder mit
- **`resetToStartCondition`**: initialisiert Board neu

### Tests
- `FieldTest`: 8 neue Tests
  - Alle 100 Felder werden erzeugt
  - Beide Spieler haben korrekte Startgebiete
  - 92 Felder sind neutral
  - Keine Überlappung der Territorien
  - Reset-Verhalten

## Bekannte Einschränkungen / Follow-up

- **Hardcoded 10×10** für DUAL_VALLEY. Mode-spezifische Größen 
  (12×12, 14×14) kommen nach dem Multisession-Merge.
- **Startgebiet aktuell = Felder unter Start-Einheiten + Basis (4 Felder)**.
  Laut Spieldesign soll es eigentlich BASE + 6 angrenzende Felder sein. 
  Wird in Follow-up Issue umgesetzt sobald Wirtschaftssystem (#60) gemergt 
  ist (Einheiten kommen dann durch Kauf, nicht von Anfang an).