### PR TITLE
Feat/61 bewegung eroberung eroberungslogik

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -128,6 +128,14 @@ class GameService(
         }
         if (friendlyOnTarget) return state
 
+        // Randfeld-Regel: Das Zielfeld muss entweder eigenes Gebiet sein
+        // oder an eigenes Gebiet angrenzen. Verhindert "Sprung-Eroberungen"
+        // in entfernte, nicht-angrenzende Gebiete.
+        val targetField = state.fields.firstOrNull { it.x == move.toX && it.y == move.toY }
+        val isOwnField = targetField?.owner == move.player
+        val isBorderField = isAdjacentToOwnTerritory(state, move.toX, move.toY, move.player)
+        if (!isOwnField && !isBorderField) return state
+
         val enemyOnTarget = state.units.firstOrNull {
             it.x == move.toX && it.y == move.toY &&
                     it.player != move.player &&

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -136,6 +136,13 @@ class GameService(
         val isBorderField = isAdjacentToOwnTerritory(state, move.toX, move.toY, move.player)
         if (!isOwnField && !isBorderField) return state
 
+        // Skelett auf Zielfeld wird "wieder eingenommen" - egal von welchem
+        // Spieler. Muss VOR dem Combat-Check passieren damit es nicht
+        // versehentlich als Verteidiger interpretiert wird.
+        state.units.removeIf {
+            it.x == move.toX && it.y == move.toY && it.type == UnitType.SKELETON
+        }
+
         val enemyOnTarget = state.units.firstOrNull {
             it.x == move.toX && it.y == move.toY &&
                     it.player != move.player &&

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -308,10 +308,16 @@ class GameService(
      * wenn alle bewegbaren Einheiten des aktuellen Spielers gezogen haben.
      */
     private fun finishMove(state: GameState, unit: GameUnit, playerName: String) {
-        // Falls die Einheit den Move ueberlebt hat, als bewegt markieren.
-        // Nach Combat kann sie aus state.units entfernt worden sein.
+        // Falls die Einheit den Move ueberlebt hat, als bewegt markieren
+        // und das Feld unter ihr erobern. Nach Combat kann sie aus
+        // state.units entfernt worden sein - dann faellt die Eroberung
+        // korrekterweise weg, weil niemand mehr auf dem Feld steht.
         if (unit in state.units) {
             unit.hasMovedThisTurn = true
+            // Eroberung: Das Feld auf dem die Einheit jetzt steht
+            // gehoert dem Spieler. Idempotent fuer eigene Felder.
+            state.fields.firstOrNull { it.x == unit.x && it.y == unit.y }
+                ?.let { it.owner = playerName }
         }
         // Auto-Switch wenn alle Einheiten gezogen haben.
         if (allMovableUnitsHaveMoved(state, playerName)) {

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -311,6 +311,21 @@ class GameService(
         }
     }
 
+    /**
+     * Prueft ob das Feld (x, y) an mindestens ein Feld grenzt das dem
+     * angegebenen Spieler gehoert. Wird genutzt um die Randfeld-Regel
+     * fuer Eroberungen durchzusetzen: nur Felder die an eigenes Gebiet
+     * angrenzen koennen erobert werden.
+     *
+     * Liefert false wenn der Spieler kein eigenes Gebiet hat.
+     */
+    private fun isAdjacentToOwnTerritory(state: GameState, x: Int, y: Int, playerName: String): Boolean {
+        return state.fields.any { field ->
+            field.owner == playerName &&
+                    HexDistance.between(field.x, field.y, x, y) == 1
+        }
+    }
+
     // WICHTIG FÜR TEST  Nur den aktuellen Stand lesen
     fun getCurrentState(state: GameState): GameState = synchronized(state.lock) {
         return state

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConquestTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConquestTest.kt
@@ -1,0 +1,80 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class FieldConquestTest {
+
+    private lateinit var gameService: GameService
+
+    @BeforeEach
+    fun setup() {
+        gameService = GameService(CombatService())
+        gameService.handleJoin("Alice")
+        gameService.handleJoin("Bob")
+    }
+
+    @Test
+    fun `moving onto neutral border field conquers it`() {
+        // Alice INFANTRY (3,2) -> (3,3): (3,3) ist neutrales Randfeld.
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY, 3, 2, 3, 3))
+
+        val field = gameService.getCurrentState().fields.first { it.x == 3 && it.y == 3 }
+        assertEquals("Alice", field.owner)
+    }
+
+    @Test
+    fun `moving to a non-border field is rejected`() {
+        // (3,4) ist nicht Alice's Feld und nicht adjacent zu Alice's Gebiet.
+        val state = gameService.handleMove(Move("Alice", UnitType.INFANTRY, 3, 2, 3, 4))
+
+        // Position unveraendert
+        val infantry = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
+        assertEquals(3, infantry.x)
+        assertEquals(2, infantry.y)
+    }
+
+    @Test
+    fun `own territory fields stay owned after move from them`() {
+        // Alice INFANTRY zieht von (3,2) auf (3,3) - (3,2) gehoert weiterhin Alice
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY, 3, 2, 3, 3))
+
+        val field = gameService.getCurrentState().fields.first { it.x == 3 && it.y == 2 }
+        assertEquals("Alice", field.owner)
+    }
+
+    @Test
+    fun `skeleton is removed when unit moves onto its tile`() {
+        val state = gameService.getCurrentState()
+        // Skelett manuell auf (3,3) platzieren (Randfeld von Alice).
+        state.units.add(GameUnit("Bob", 3, 3, UnitType.SKELETON))
+
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY, 3, 2, 3, 3))
+
+        val skeletonsLeft = state.units.filter { it.type == UnitType.SKELETON }
+        assertTrue(skeletonsLeft.isEmpty(), "Skelett haette entfernt werden muessen")
+    }
+
+    @Test
+    fun `conquered field becomes part of player territory`() {
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY, 3, 2, 3, 3))
+
+        val aliceFields = gameService.getCurrentState().fields.count { it.owner == "Alice" }
+        // 4 Startfelder + 1 eroberte = 5
+        assertEquals(5, aliceFields)
+    }
+
+    @Test
+    fun `enemy field adjacent to own territory can be conquered`() {
+        val state = gameService.getCurrentState()
+        // Bob's Feld manuell auf (3,3) setzen (= adjacent zu Alice's (3,2)).
+        state.fields.first { it.x == 3 && it.y == 3 }.owner = "Bob"
+
+        // Alice INFANTRY zieht hin und erobert.
+        gameService.handleMove(Move("Alice", UnitType.INFANTRY, 3, 2, 3, 3))
+
+        val updated = state.fields.first { it.x == 3 && it.y == 3 }
+        assertEquals("Alice", updated.owner)
+    }
+}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/UnitTypeTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/UnitTypeTest.kt
@@ -37,6 +37,23 @@ class UnitTypeTest {
             GameUnit("Bob", 6, 5, UnitType.INFANTRY),
             GameUnit("Bob", 7, 5, UnitType.CAVALRY)
         ))
+
+        // Board und Startgebiete initialisieren (analog handleJoin).
+        // Wird gebraucht damit die Randfeld-Regel in handleMove greifen
+        // kann - ohne Fields wuerde jeder Move als "kein Randfeld"
+        // abgelehnt.
+        state.fields.clear()
+        for (x in 0 until 10) {
+            for (y in 0 until 10) {
+                state.fields.add(Field(x, y))
+            }
+        }
+        listOf(2 to 2, 3 to 2, 4 to 2, 3 to 0).forEach { (x, y) ->
+            state.fields.first { it.x == x && it.y == y }.owner = "Alice"
+        }
+        listOf(5 to 5, 6 to 5, 7 to 5, 6 to 7).forEach { (x, y) ->
+            state.fields.first { it.x == x && it.y == y }.owner = "Bob"
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary


Eroberungslogik mit Randfeld-Regel implementiert: eine Einheit kann nur 
auf Felder ziehen die zum eigenen Gebiet gehören oder direkt daran 
angrenzen. Bewegte Felder werden automatisch erobert. Skelette auf 
Zielfeldern werden "wieder eingenommen" (entfernt) ohne Combat 
auszulösen.

## Changes

### Backend Logic
- **`GameService.isAdjacentToOwnTerritory(x, y, player)`**: Neue 
  Helper-Methode prüft via `HexDistance.between(...) == 1` ob ein Feld 
  an mindestens eines der Spieler-Felder angrenzt
- **`GameService.handleMove`**:
  - Randfeld-Validierung: Move abgelehnt wenn Zielfeld weder eigenes 
    noch Randfeld ist (verhindert "Sprung-Eroberungen" in entfernte 
    nicht-angrenzende Gebiete)
  - Skelett auf Zielfeld wird vor Combat-Check entfernt
- **`GameService.finishMove`**: Feld unter überlebender Einheit bekommt 
  automatisch den Spieler als Owner

### Tests
- **`FieldConquestTest`** (neu): 6 Tests
  - Erobern eines neutralen Randfelds
  - Ablehnung von Sprung-Eroberung
  - Eigene Felder bleiben nach Move
  - Skelett-Entfernung beim Drüberziehen
  - Territorium wächst nach Eroberung
  - Eroberung von gegnerischem Randfeld
- **`UnitTypeTest.setup`**: Field-Initialisierung ergänzt (forciert 
  durch neue Randfeld-Regel — ohne Fields würden alle Moves im manuellen 
  Setup als "kein Randfeld" abgelehnt)

## Verhalten der Regel

Ein Move auf Zielfeld (toX, toY) ist erlaubt wenn:
1. **Distanz ≤ 2** vom Startfeld (bereits durch #102 implementiert)
2. **Eigenes Feld** (`owner == player`) ODER **Randfeld** (mindestens 
   ein Nachbar gehört dem Spieler)

Beispiel mit Territorium `{(5,4), (4,4), (6,4), (5,3)}` und Einheit 
auf (5,5):
- (5,5) → (5,3): ✅ erlaubt (eigenes Feld, Distanz 2)
- (5,5) → (6,5): ✅ erlaubt (Randfeld, adjacent zu (6,4))
- (5,5) → (5,7): ❌ abgelehnt (Distanz 2, aber nicht adjacent zu Territorium)
- (5,5) → (6,6): ❌ abgelehnt (Distanz 1, aber nicht adjacent zu Territorium)




