### PR TITLE
Issue #85: Automatic Game Start Based on Game Mode

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -118,7 +118,7 @@ class WebSocketBrokerController(
 
         val currentState = gameService.getCurrentState(room.gameState)
 
-        if (currentState.players.size >= GameService.MAX_PLAYERS &&
+        if (currentState.players.size >= room.mode.maxPlayers &&
             !currentState.players.any { it.name == playerName }) {
 
             sendError(
@@ -140,13 +140,6 @@ class WebSocketBrokerController(
             roomId,
             state
         )
-
-       /* if (
-            state.players.size == room.mode.maxPlayers &&
-            state.status == GameStatus.WAITING_FOR_PLAYERS
-        ) {
-            gameService.startGame(room.gameState)
-        }*/
 
         return state
     }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -141,6 +141,13 @@ class WebSocketBrokerController(
             state
         )
 
+       /* if (
+            state.players.size == room.mode.maxPlayers &&
+            state.status == GameStatus.WAITING_FOR_PLAYERS
+        ) {
+            gameService.startGame(room.gameState)
+        }*/
+
         return state
     }
 

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -15,21 +15,24 @@ class GameService(
 
     fun handleJoin(state: GameState, playerName: String, sessionId:String=""): GameState = synchronized(state.lock) {
         // Spieler hinzufügen, falls noch nicht vorhanden und Platz ist
-
         if (!state.players.any{it.name == playerName} && state.players.size < state.gameMode.maxPlayers) {
-            val color = if (state.players.isEmpty()) PlayerColor.RED else PlayerColor.BLUE
-            state.players.add(Player(playerName, sessionId,color))
-            println("JOIN: $playerName")
+
+            // Dynamische Farbauswahl für bis zu 4 Spieler anhand der aktuellen Listengröße
+            val colors = listOf(PlayerColor.RED, PlayerColor.BLUE, PlayerColor.GREEN, PlayerColor.YELLOW)
+            val color = colors.getOrElse(state.players.size) { PlayerColor.RED }
+
+            state.players.add(Player(playerName, sessionId, color))
+            println("JOIN: $playerName mit Farbe $color")
         }
 
-        // Automatischer Start bei 2 Spielern
+        // Automatischer Start bei Erreichen der maximalen Spieleranzahl des Modus
         if (state.players.size == state.gameMode.maxPlayers && state.units.isEmpty()) {
             println("players=${state.players.size}, max=${state.gameMode.maxPlayers}")
             startGame(state)
         }
         return state
-
     }
+
 
     fun startGame(state: GameState) {
         when(state.gameMode) {
@@ -77,19 +80,96 @@ class GameService(
         println("Service: GAME STARTED")
     }
 
-    private fun startTriadOutpostGame(state: GameState) {
-        state.currentTurn = state.players.first().name
-        state.status = GameStatus.IN_PROGRESS
 
+    private fun startTriadOutpostGame(state: GameState) {
+        val p1 = state.players[0]
+        val p2 = state.players[1]
+        val p3 = state.players[2]
+
+        // Start-Einheiten für 3 Spieler setzen
+        // Index 0: ARCHER, Index 1: INFANTRY, Index 2: CAVALRY
+        val startPositionsP1 = listOf(
+            Pair(4, 2),  // ARCHER (Süden)
+            Pair(5, 2),  // INFANTRY
+            Pair(6, 2)   // CAVALRY
+        )
+
+        val startPositionsP2 = listOf(
+            Pair(2, 5),  // ARCHER (Nordwesten)
+            Pair(2, 6),  // INFANTRY
+            Pair(3, 6)   // CAVALRY
+        )
+
+        val startPositionsP3 = listOf(
+            Pair(7, 6),  // ARCHER (Nordosten)
+            Pair(8, 6),  // INFANTRY
+            Pair(8, 5)   // CAVALRY
+        )
+
+        UnitType.entries.filter { it != UnitType.SKELETON }.forEachIndexed { index, type ->
+            val (x1, y1) = startPositionsP1[index]
+            val (x2, y2) = startPositionsP2[index]
+            val (x3, y3) = startPositionsP3[index]
+
+            state.units.add(GameUnit(p1.name, x1, y1, type))
+            state.units.add(GameUnit(p2.name, x2, y2, type))
+            state.units.add(GameUnit(p3.name, x3, y3, type))
+        }
+
+        state.currentTurn = p1.name
+        state.status = GameStatus.IN_PROGRESS
         println("Service: TRIAD OUTPOST GAME STARTED")
     }
 
     private fun startBattlefieldPeaksGame(state: GameState) {
-        state.currentTurn = state.players.first().name
-        state.status = GameStatus.IN_PROGRESS
+        val p1 = state.players[0]
+        val p2 = state.players[1]
+        val p3 = state.players[2]
+        val p4 = state.players[3]
 
+        // Start-Einheiten für 4 Spieler setzen
+        // Index 0: ARCHER, Index 1: INFANTRY, Index 2: CAVALRY
+        val startPositionsP1 = listOf(
+            Pair(4, 1),  // ARCHER (Süden)
+            Pair(5, 1),  // INFANTRY
+            Pair(6, 1)   // CAVALRY
+        )
+
+        val startPositionsP2 = listOf(
+            Pair(1, 4),  // ARCHER (Westen)
+            Pair(1, 5),  // INFANTRY
+            Pair(1, 6)   // CAVALRY
+        )
+
+        val startPositionsP3 = listOf(
+            Pair(9, 4),  // ARCHER (Osten)
+            Pair(9, 5),  // INFANTRY
+            Pair(9, 6)   // CAVALRY
+        )
+
+        val startPositionsP4 = listOf(
+            Pair(4, 9),  // ARCHER (Norden)
+            Pair(5, 9),  // INFANTRY
+            Pair(6, 9)   // CAVALRY
+        )
+
+        UnitType.entries.filter { it != UnitType.SKELETON }.forEachIndexed { index, type ->
+            val (x1, y1) = startPositionsP1[index]
+            val (x2, y2) = startPositionsP2[index]
+            val (x3, y3) = startPositionsP3[index]
+            val (x4, y4) = startPositionsP4[index]
+
+            state.units.add(GameUnit(p1.name, x1, y1, type))
+            state.units.add(GameUnit(p2.name, x2, y2, type))
+            state.units.add(GameUnit(p3.name, x3, y3, type))
+            state.units.add(GameUnit(p4.name, x4, y4, type))
+        }
+
+        state.currentTurn = p1.name
+        state.status = GameStatus.IN_PROGRESS
         println("Service: BATTLEFIELD PEAKS GAME STARTED")
     }
+
 
     fun handleMove(state: GameState, move: Move): GameState = synchronized(state.lock) {
         if (state.status != GameStatus.IN_PROGRESS) return state
@@ -126,9 +206,8 @@ class GameService(
         unit.x = move.toX
         unit.y = move.toY
 
-        val (p1, p2) = state.players
-        state.currentTurn = if (state.currentTurn == p1.name) p2.name else p1.name
-
+        // Ersetzt die alte 2-Spieler-Zuweisung durch den zentralen Rundenwechsel
+        switchTurn(state)
         return state
     }
 
@@ -139,15 +218,31 @@ class GameService(
 
 
     private fun switchTurn(state: GameState) {
+        // Falls das Spiel im klassischen 2-Spieler-Modus ist (deckt alle alten Tests ab)
+        if (state.players.size == 2) {
+            val p1 = state.players[0]
+            val p2 = state.players[1]
 
-        val (p1, p2) = state.players
+            // alte, originale Logik
+            state.currentTurn = if (state.currentTurn == p1.name) p2.name else p1.name
+            return
+        }
 
-        state.currentTurn =
-            if (state.currentTurn == p1.name)
-                p2.name
-            else
-                p1.name
+        // Dynamische Rotation für 3 oder 4 Spieler im echten Spiel
+        if (state.players.isNotEmpty()) {
+            val currentIndex = state.players.indexOfFirst { it.name == state.currentTurn }
+            if (currentIndex != -1) {
+                val nextIndex = (currentIndex + 1) % state.players.size
+                state.currentTurn = state.players[nextIndex].name
+            } else {
+                // Falls der aktuelle Turn aus irgendeinem Grund nicht matcht, fängt der Erste an
+                state.currentTurn = state.players.firstOrNull()?.name
+            }
+        }
     }
+
+
+
 
     // WICHTIG FÜR TEST  Nur den aktuellen Stand lesen
     fun getCurrentState(state: GameState): GameState = synchronized(state.lock) {

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -16,44 +16,27 @@ class GameService(
     fun handleJoin(state: GameState, playerName: String, sessionId:String=""): GameState = synchronized(state.lock) {
         // Spieler hinzufügen, falls noch nicht vorhanden und Platz ist
 
-        if (!state.players.any{it.name == playerName} && state.players.size < MAX_PLAYERS) {
+        if (!state.players.any{it.name == playerName} && state.players.size < state.gameMode.maxPlayers) {
             val color = if (state.players.isEmpty()) PlayerColor.RED else PlayerColor.BLUE
             state.players.add(Player(playerName, sessionId,color))
             println("JOIN: $playerName")
         }
 
         // Automatischer Start bei 2 Spielern
-        if (state.players.size == 2 && state.units.isEmpty()) {
-            val p1 = state.players[0]
-            val p2 = state.players[1]
-
-            // Start-Einheiten setzen
-            val startPositionsP1 = listOf(
-                Pair(2, 2),  // ARCHER
-                Pair(3, 2),  // INFANTRY
-                Pair(4, 2)   // CAVALRY
-            )
-
-            val startPositionsP2 = listOf(
-                Pair(5, 5),
-                Pair(6, 5),
-                Pair(7, 5)
-            )
-
-            UnitType.entries.filter { it != UnitType.SKELETON }.forEachIndexed { index, type ->
-                val (x1, y1) = startPositionsP1[index]
-                val (x2, y2) = startPositionsP2[index]
-
-                state.units.add(GameUnit(p1.name, x1, y1, type))
-                state.units.add(GameUnit(p2.name, x2, y2, type))
-            }
-
-            state.currentTurn = p1.name
-            state.status = GameStatus.IN_PROGRESS
-            println("Service: GAME STARTED")
+        if (state.players.size == state.gameMode.maxPlayers && state.units.isEmpty()) {
+            println("players=${state.players.size}, max=${state.gameMode.maxPlayers}")
+            startGame(state)
         }
         return state
 
+    }
+
+    fun startGame(state: GameState) {
+        when(state.gameMode) {
+            GameMode.DUAL_VALLEY -> startDualValleyGame(state)
+            GameMode.TRIAD_OUTPOST -> startTriadOutpostGame(state)
+            GameMode.BATTLEFIELD_PEAKS -> startBattlefieldPeaksGame(state)
+        }
     }
 
     //Bridge Method handleJoin
@@ -61,6 +44,52 @@ class GameService(
         playerName: String,
         sessionId: String = ""
     ): GameState = handleJoin(this.gameState, playerName, sessionId)
+
+
+    private fun startDualValleyGame(state: GameState)
+    {
+        val p1 = state.players[0]
+        val p2 = state.players[1]
+
+        // Start-Einheiten setzen
+        val startPositionsP1 = listOf(
+            Pair(2, 2),  // ARCHER
+            Pair(3, 2),  // INFANTRY
+            Pair(4, 2)   // CAVALRY
+        )
+
+        val startPositionsP2 = listOf(
+            Pair(5, 5),
+            Pair(6, 5),
+            Pair(7, 5)
+        )
+
+        UnitType.entries.filter { it != UnitType.SKELETON }.forEachIndexed { index, type ->
+            val (x1, y1) = startPositionsP1[index]
+            val (x2, y2) = startPositionsP2[index]
+
+            state.units.add(GameUnit(p1.name, x1, y1, type))
+            state.units.add(GameUnit(p2.name, x2, y2, type))
+        }
+
+        state.currentTurn = p1.name
+        state.status = GameStatus.IN_PROGRESS
+        println("Service: GAME STARTED")
+    }
+
+    private fun startTriadOutpostGame(state: GameState) {
+        state.currentTurn = state.players.first().name
+        state.status = GameStatus.IN_PROGRESS
+
+        println("Service: TRIAD OUTPOST GAME STARTED")
+    }
+
+    private fun startBattlefieldPeaksGame(state: GameState) {
+        state.currentTurn = state.players.first().name
+        state.status = GameStatus.IN_PROGRESS
+
+        println("Service: BATTLEFIELD PEAKS GAME STARTED")
+    }
 
     fun handleMove(state: GameState, move: Move): GameState = synchronized(state.lock) {
         if (state.status != GameStatus.IN_PROGRESS) return state

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -13,6 +13,23 @@ class GameService(
         const val MAX_PLAYERS = 2
     }
 
+    /**
+     * Adds a player to the given game state if there is still room available.
+     *
+     * The maximum number of players is determined by the current
+     * [GameMode] stored in the provided [GameState].
+     *
+     * When the required number of players for the selected game mode
+     * has joined, the game is started automatically and the initial
+     * unit positions are created.
+     *
+     * This method is thread-safe and synchronizes on the state's lock.
+     *
+     * @param state The game state to modify.
+     * @param playerName The name of the joining player.
+     * @param sessionId The WebSocket session identifier of the player.
+     * @return The updated game state.
+     */
     fun handleJoin(state: GameState, playerName: String, sessionId:String=""): GameState = synchronized(state.lock) {
         // Spieler hinzufügen, falls noch nicht vorhanden und Platz ist
         if (!state.players.any{it.name == playerName} && state.players.size < state.gameMode.maxPlayers) {
@@ -34,7 +51,21 @@ class GameService(
     }
 
 
-    fun startGame(state: GameState) {
+    /**
+     * Starts a game according to the game mode stored in the provided state.
+     *
+     * Depending on the selected [GameMode], the corresponding initial
+     * unit setup is created and the game is transitioned to
+     * [GameStatus.IN_PROGRESS].
+     *
+     * Supported game modes:
+     * - [GameMode.DUAL_VALLEY] (2 players)
+     * - [GameMode.TRIAD_OUTPOST] (3 players)
+     * - [GameMode.BATTLEFIELD_PEAKS] (4 players)
+     *
+     * @param state The game state to initialize.
+     */
+     fun startGame(state: GameState) {
         when(state.gameMode) {
             GameMode.DUAL_VALLEY -> startDualValleyGame(state)
             GameMode.TRIAD_OUTPOST -> startTriadOutpostGame(state)
@@ -49,6 +80,18 @@ class GameService(
     ): GameState = handleJoin(this.gameState, playerName, sessionId)
 
 
+    /**
+     * Initializes a DUAL_VALLEY game with two players.
+     *
+     * Creates the default starting units for both players at their
+     * predefined starting positions on opposite sides of the map.
+     *
+     * After all units have been placed, the first player receives the
+     * opening turn and the game status is set to
+     * [GameStatus.IN_PROGRESS].
+     *
+     * @param state The game state to initialize.
+     */
     private fun startDualValleyGame(state: GameState)
     {
         val p1 = state.players[0]
@@ -81,6 +124,20 @@ class GameService(
     }
 
 
+    /**
+     * Initializes a TRIAD_OUTPOST game with three players.
+     *
+     * Creates the starting units for all three players at predefined
+     * positions arranged around the map center in a triangular layout.
+     * This setup provides each player with an equal distance to the
+     * center and to the opposing players.
+     *
+     * After all units have been placed, the first player receives the
+     * opening turn and the game status is set to
+     * [GameStatus.IN_PROGRESS].
+     *
+     * @param state The game state to initialize.
+     */
     private fun startTriadOutpostGame(state: GameState) {
         val p1 = state.players[0]
         val p2 = state.players[1]
@@ -121,6 +178,20 @@ class GameService(
         println("Service: TRIAD OUTPOST GAME STARTED")
     }
 
+    /**
+     * Initializes a BATTLEFIELD_PEAKS game with four players.
+     *
+     * Creates the starting units for all four players at predefined
+     * positions arranged in a cross-shaped layout around the map.
+     * Each player starts from a different edge of the battlefield,
+     * providing a balanced setup with equal access to the central area.
+     *
+     * After all units have been placed, the first player receives the
+     * opening turn and the game status is set to
+     * [GameStatus.IN_PROGRESS].
+     *
+     * @param state The game state to initialize.
+     */
     private fun startBattlefieldPeaksGame(state: GameState) {
         val p1 = state.players[0]
         val p2 = state.players[1]
@@ -170,7 +241,23 @@ class GameService(
         println("Service: BATTLEFIELD PEAKS GAME STARTED")
     }
 
-
+    /*
+    * Executes a player's move and updates the game state accordingly.
+    *
+    * The move is validated against the current game rules. If the move
+    * is valid, the selected unit is moved to its new position and the
+    * turn is passed to the next player.
+    *
+    * Turn rotation supports both the classic two-player mode and the
+    * multiplayer game modes with three or four players.
+    *
+    * This method is thread-safe and synchronizes on the state's lock.
+    *
+    * @param state The game state to modify.
+    * @param move The move to execute.
+    * @return The updated game state.
+    * @throws IllegalArgumentException If the move is invalid.
+    */
     fun handleMove(state: GameState, move: Move): GameState = synchronized(state.lock) {
         if (state.status != GameStatus.IN_PROGRESS) return state
         if (move.player != state.currentTurn) return state
@@ -217,6 +304,22 @@ class GameService(
     ): GameState = handleMove(this.gameState, move)
 
 
+    /**
+     * Advances the turn to the next player.
+     *
+     * For games with two players, the original alternating turn logic
+     * is used to preserve the behaviour of the classic game mode and
+     * existing tests.
+     *
+     * For games with three or four players, turns are rotated through
+     * the player list in a circular manner. After the last player has
+     * taken a turn, the first player becomes active again.
+     *
+     * If the current player cannot be found in the player list, the
+     * first player is selected as a fallback.
+     *
+     * @param state The game state whose active player should be updated.
+     */
     private fun switchTurn(state: GameState) {
         // Falls das Spiel im klassischen 2-Spieler-Modus ist (deckt alle alten Tests ab)
         if (state.players.size == 2) {
@@ -240,9 +343,6 @@ class GameService(
             }
         }
     }
-
-
-
 
     // WICHTIG FÜR TEST  Nur den aktuellen Stand lesen
     fun getCurrentState(state: GameState): GameState = synchronized(state.lock) {
@@ -300,6 +400,21 @@ class GameService(
     //Bridge Method resetToStartCondition
     fun resetToStartCondition(): GameState = resetToStartCondition(this.gameState)
 
+    /**
+     * Removes a player from the game based on the associated session ID.
+     *
+     * If a matching player is found, the player and all of their units
+     * are removed from the game state.
+     *
+     * If the disconnected player was part of an active game, the game is
+     * marked as [GameStatus.FINISHED].
+     *
+     * This method is thread-safe and synchronizes on the state's lock.
+     *
+     * @param state The game state to update.
+     * @param sessionId The session identifier of the disconnected player.
+     * @return The updated game state.
+     */
     fun handleDisconnect(state: GameState, sessionId: String): GameState = synchronized(state.lock) {
         val player = state.players.find { it.sessionId == sessionId }
             ?: return state

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -256,7 +256,7 @@ class GameService(
     * @param state The game state to modify.
     * @param move The move to execute.
     * @return The updated game state.
-    * @throws IllegalArgumentException If the move is invalid.
+
     */
     fun handleMove(state: GameState, move: Move): GameState = synchronized(state.lock) {
         if (state.status != GameStatus.IN_PROGRESS) return state

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameState.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameState.kt
@@ -11,7 +11,8 @@ data class GameState(
     val players: MutableList<Player> = mutableListOf(),
     val units: MutableList<GameUnit> = mutableListOf(),
     var currentTurn: String? = null,
-    var status: GameStatus = GameStatus.WAITING_FOR_PLAYERS
+    var status: GameStatus = GameStatus.WAITING_FOR_PLAYERS,
+    var gameMode: GameMode = GameMode.DUAL_VALLEY
 )
 {
     @JsonIgnore

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/PlayerColor.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/PlayerColor.kt
@@ -1,5 +1,12 @@
 package at.aau.hexabrawl.websocketserver.model
 
+/**
+ * Represents the color assigned to a player.
+ *
+ * Colors are assigned automatically when players join a game.
+ * Each player receives a unique color that can be used for
+ * identification in multiplayer matches.
+ */
 enum class PlayerColor {
     RED,
     BLUE,

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/PlayerColor.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/PlayerColor.kt
@@ -1,5 +1,8 @@
 package at.aau.hexabrawl.websocketserver.model
 
 enum class PlayerColor {
-    RED,BLUE
+    RED,
+    BLUE,
+    GREEN,   // Für Spieler 3
+    YELLOW   // Für Spieler 4
 }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/RoomRegistry.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/RoomRegistry.kt
@@ -18,7 +18,7 @@ class RoomRegistry {
         val roomId = UUID.randomUUID().toString()
         while (true) {
             val joinCode = generateJoinCode()
-            val room = Room(roomId, joinCode, mode)
+            val room = Room(roomId, joinCode, mode, GameState(gameMode = mode))
             if (byJoinCode.putIfAbsent(joinCode, room) == null) {
                 rooms[roomId] = room
                 return room

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -794,4 +794,5 @@ class WebSocketBrokerControllerTest {
             }
         )
     }
+
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -795,4 +795,41 @@ class WebSocketBrokerControllerTest {
         )
     }
 
+    @Test
+    fun `joining final player broadcasts started game state`() {
+
+        val room = roomRegistry.createRoom(
+            GameMode.TRIAD_OUTPOST
+        )
+
+        controller.joinRoom(
+            room.roomId,
+            "P1",
+            headerAccessor
+        )
+
+        controller.joinRoom(
+            room.roomId,
+            "P2",
+            headerAccessor
+        )
+
+        val state = controller.joinRoom(
+            room.roomId,
+            "P3",
+            headerAccessor
+        )
+
+        assertEquals(
+            GameStatus.IN_PROGRESS,
+            state?.status
+        )
+
+        verify(messagingTemplate, atLeastOnce())
+            .convertAndSend(
+                eq("/topic/rooms/${room.roomId}/state"),
+                any(GameState::class.java)
+            )
+    }
+
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -794,5 +794,4 @@ class WebSocketBrokerControllerTest {
             }
         )
     }
-
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
@@ -363,4 +363,83 @@ class GameModelTest {
         )
     }
 
+
+    @Test
+    fun `battlefield peaks does not start after third player joins`() {
+
+        val gameService = GameService(CombatService())
+        val roomRegistry = RoomRegistry()
+
+        val room = roomRegistry.createRoom(
+            GameMode.BATTLEFIELD_PEAKS
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "P1",
+            "session-1"
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "P2",
+            "session-2"
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "P3",
+            "session-3"
+        )
+
+        assertEquals(
+            GameStatus.WAITING_FOR_PLAYERS,
+            room.gameState.status
+        )
+    }
+
+    @Test
+    fun `battlefield peaks starts when fourth player joins`() {
+
+        val gameService = GameService(CombatService())
+        val roomRegistry = RoomRegistry()
+
+        val room = roomRegistry.createRoom(
+            GameMode.BATTLEFIELD_PEAKS
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "P1",
+            "session-1"
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "P2",
+            "session-2"
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "P3",
+            "session-3"
+        )
+
+        assertEquals(
+            GameStatus.WAITING_FOR_PLAYERS,
+            room.gameState.status
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "P4",
+            "session-4"
+        )
+
+        assertEquals(
+            GameStatus.IN_PROGRESS,
+            room.gameState.status
+        )
+    }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
@@ -294,4 +294,73 @@ class GameModelTest {
         assertSame(state1, result)
     }
 
+
+    @Test
+    fun `triad outpost does not start after second player joins`() {
+        val gameService = GameService(CombatService())
+        val roomRegistry = RoomRegistry()
+
+        val room = roomRegistry.createRoom(
+            GameMode.TRIAD_OUTPOST
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "P1",
+            "session-1"
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "P2",
+            "session-2"
+        )
+        println(room.mode)
+        println(room.gameState.gameMode)
+
+        assertEquals(
+            GameStatus.WAITING_FOR_PLAYERS,
+            room.gameState.status
+        )
+    }
+
+    @Test
+    fun `triad outpost starts when third player joins`() {
+
+        val gameService = GameService(CombatService())
+        val roomRegistry = RoomRegistry()
+
+        val room = roomRegistry.createRoom(
+            GameMode.TRIAD_OUTPOST
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "P1",
+            "session-1"
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "P2",
+            "session-2"
+        )
+
+        assertEquals(
+            GameStatus.WAITING_FOR_PLAYERS,
+            room.gameState.status
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "P3",
+            "session-3"
+        )
+
+        assertEquals(
+            GameStatus.IN_PROGRESS,
+            room.gameState.status
+        )
+    }
+
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
@@ -442,4 +442,98 @@ class GameModelTest {
             room.gameState.status
         )
     }
+
+    @Test
+    fun `triad outpost switches turn from first to second player`() {
+
+        val roomRegistry = RoomRegistry()
+        val gameService = GameService(CombatService())
+
+        val room = roomRegistry.createRoom(
+            GameMode.TRIAD_OUTPOST
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "P1",
+            "session-1"
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "P2",
+            "session-2"
+        )
+
+        gameService.handleJoin(
+            room.gameState,
+            "P3",
+            "session-3"
+        )
+
+        assertEquals(
+            "P1",
+            room.gameState.currentTurn
+        )
+
+        val move = Move(
+            player = "P1",
+            type = UnitType.INFANTRY,
+            fromX = 5,
+            fromY = 2,
+            toX = 5,
+            toY = 3
+        )
+
+        val state = gameService.handleMove(
+            room.gameState,
+            move
+        )
+
+        assertEquals(
+            "P2",
+            state.currentTurn
+        )
+    }
+
+    @Test
+    fun `battlefield peaks switches turn from first to second player`() {
+
+        val roomRegistry = RoomRegistry()
+        val gameService = GameService(CombatService())
+
+        val room = roomRegistry.createRoom(
+            GameMode.BATTLEFIELD_PEAKS
+        )
+
+        gameService.handleJoin(room.gameState, "P1", "session-1")
+        gameService.handleJoin(room.gameState, "P2", "session-2")
+        gameService.handleJoin(room.gameState, "P3", "session-3")
+        gameService.handleJoin(room.gameState, "P4", "session-4")
+
+        assertEquals(
+            "P1",
+            room.gameState.currentTurn
+        )
+
+        val move = Move(
+            player = "P1",
+            type = UnitType.INFANTRY,
+            fromX = 5,
+            fromY = 1,
+            toX = 5,
+            toY = 2
+        )
+
+        val state = gameService.handleMove(
+            room.gameState,
+            move
+        )
+
+        assertEquals(
+            "P2",
+            state.currentTurn
+        )
+    }
+
 }


### PR DESCRIPTION
## Summary

This PR introduces automatic game start behavior based on the selected game mode.

Games now start automatically when the required number of players for the selected mode has joined the room:

* `DUAL_VALLEY` → 2 players
* `TRIAD_OUTPOST` → 3 players
* `BATTLEFIELD_PEAKS` → 4 players

The implementation extends the existing room-based architecture and preserves compatibility with the legacy two-player STOMP endpoints.

## Changes

### Game Mode Aware Player Limits

* Added `gameMode` to `GameState`
* Initialized `gameMode` when creating rooms
* Replaced fixed player limits in room-based game logic with `gameMode.maxPlayers`

### Automatic Game Start

* Added `startGame()` dispatcher
* Automatically starts the correct game mode when the required number of players has joined
* Supports:

  * `startDualValleyGame()`
  * `startTriadOutpostGame()`
  * `startBattlefieldPeaksGame()`

### Multiplayer Start Positions

Implemented dedicated starting layouts for:

* `TRIAD_OUTPOST` (3 players)
* `BATTLEFIELD_PEAKS` (4 players)

Each player receives the standard starting unit set at predefined positions.

### Multiplayer Turn Rotation

Extended turn switching logic to support:

* 2-player games (existing behavior preserved)
* 3-player games
* 4-player games

Turns are rotated through the player list in a circular manner.

### Broadcast Behaviour

Verified that room subscribers receive updated room states when the final player joins and the game automatically transitions to `IN_PROGRESS`.

### Documentation

Added KDocs for:

* `handleJoin`
* `startGame`
* `startDualValleyGame`
* `startTriadOutpostGame`
* `startBattlefieldPeaksGame`
* `handleMove`
* `switchTurn`
* `handleDisconnect`
* `PlayerColor`

## Testing

Added and updated tests for:

* TRIAD_OUTPOST auto-start
* BATTLEFIELD_PEAKS auto-start
* Multiplayer turn rotation
* Game start broadcasts
* Game mode specific player limits

All tests pass successfully.

## Result

Rooms now automatically start games according to their configured game mode while maintaining compatibility with the existing two-player implementation.
