### PR TITLE
test(issue-87): verify room state isolation across multiple rooms

### DIFF
--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/integration/MultiRoomIntegrationTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/integration/MultiRoomIntegrationTest.kt
@@ -1,0 +1,136 @@
+package at.aau.hexabrawl.websocketserver.integration
+
+import org.junit.jupiter.api.Test
+import at.aau.hexabrawl.websocketserver.model.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+
+class MultiRoomIntegrationTest {
+
+    @Autowired
+    private lateinit var roomRegistry: RoomRegistry
+
+    @Autowired
+    private lateinit var gameService: GameService
+
+    //Test zurPrüfung ob Test-Infrastruktur funktioniert
+    @Test
+    fun `spring injects required beans`() {
+
+        assertNotNull(roomRegistry)
+        assertNotNull(gameService)
+    }
+
+    @Test
+    fun `rooms run independently without state leaks`() {
+
+        //Nur die Räume erzeugen:
+        val roomA = roomRegistry.createRoom(
+            GameMode.DUAL_VALLEY
+        )
+
+        val roomB = roomRegistry.createRoom(
+            GameMode.DUAL_VALLEY
+        )
+
+        assertNotSame(
+            roomA.gameState,
+            roomB.gameState
+        )
+
+        //Spieler beitreten lassen:
+        gameService.handleJoin(
+            roomA.gameState,
+            "Josef",
+            "a1"
+        )
+
+        gameService.handleJoin(
+            roomA.gameState,
+            "Marie",
+            "a2"
+        )
+
+        gameService.handleJoin(
+            roomB.gameState,
+            "Benedikt",
+            "b1"
+        )
+
+        gameService.handleJoin(
+            roomB.gameState,
+            "Amalia",
+            "b2"
+        )
+
+        //prüfen:
+        assertEquals(
+            GameStatus.IN_PROGRESS,
+            roomA.gameState.status
+        )
+
+        assertEquals(
+            GameStatus.IN_PROGRESS,
+            roomB.gameState.status
+        )
+
+        //State-Leak-Test
+        val unitsBefore = roomB.gameState.units.map {
+            GameUnit(
+                it.player,
+                it.x,
+                it.y,
+                it.type
+            )
+        }
+
+        val turnBefore = roomB.gameState.currentTurn
+
+        //Move in Raum A
+        val move = Move(
+            player = "Josef",
+            type = UnitType.INFANTRY,
+            fromX = 3,
+            fromY = 2,
+            toX = 3,
+            toY = 3
+        )
+
+        gameService.handleMove(
+            roomA.gameState,
+            move
+        )
+
+        //prüfen
+        assertEquals(
+            "Marie",
+            roomA.gameState.currentTurn
+        )
+
+        //Der eigentliche Nachweis gegen State-Leaks
+        assertEquals(
+            unitsBefore,
+            roomB.gameState.units
+        )
+
+        assertEquals(
+            turnBefore,
+            roomB.gameState.currentTurn
+        )
+
+        assertEquals(
+            GameStatus.IN_PROGRESS,
+            roomB.gameState.status
+        )
+
+    }
+
+}


### PR DESCRIPTION
## Summary

This pull request adds an integration test that verifies room isolation in the multi-room architecture.

### Changes

* Added new integration test class:

  * `MultiRoomIntegrationTest`
* Added verification that multiple rooms can run in parallel
* Added verification that each room owns an independent `GameState`
* Added verification that actions performed in one room do not affect another room

### Test Scenario

The integration test creates two independent rooms:

* Room A

  * Josef
  * Marie

* Room B

  * Benedikt
  * Amalia

Both rooms start automatically after the required number of players join.

A valid move is executed in Room A. The test verifies that:

* Room A is updated correctly
* Turn rotation in Room A works as expected
* Room B remains completely unchanged
* No state leak occurs between rooms

### Acceptance Criteria

* [x] Test with two parallel rooms
* [x] No state leak between rooms
* [x] Both rooms run independently
* [x] Automated and reproducible integration test

### Verification

* All tests pass successfully (`186` tests)
* Multi-room state isolation verified
* Spring Boot integration test infrastructure validated
