### PR TITLE
Fix/turn switch consistency multimode

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -424,6 +424,13 @@ class GameService(
      * Wird nach jedem erfolgreichen Move aufgerufen. Markiert die Einheit
      * als bewegt, erobert das Feld und switcht automatisch den Turn wenn
      * alle bewegbaren Einheiten des aktuellen Spielers gezogen haben.
+     *
+     * Verhalten ist fuer alle Modi (DUAL_VALLEY, TRIAD_OUTPOST,
+     * BATTLEFIELD_PEAKS) identisch: der Spieler darf jede seiner
+     * bewegbaren Einheiten maximal einmal pro Zug bewegen. Auto-Switch
+     * passiert erst, wenn alle bewegbaren Einheiten gezogen haben.
+     * Vorzeitig kann der Spieler ueber den /end-turn-Endpoint manuell
+     * wechseln.
      */
     private fun finishMove(state: GameState, unit: GameUnit, playerName: String) {
         if (unit in state.units) {
@@ -431,13 +438,7 @@ class GameService(
             state.fields.firstOrNull { it.x == unit.x && it.y == unit.y }
                 ?.let { it.owner = playerName }
         }
-        // DUAL_VALLEY: Turn erst wechseln wenn alle Einheiten gezogen haben.
-        // TRIAD/BATTLEFIELD: sofort nach jedem Zug wechseln.
-        if (state.gameMode == GameMode.DUAL_VALLEY) {
-            if (allMovableUnitsHaveMoved(state, playerName)) {
-                switchTurn(state)
-            }
-        } else {
+        if (allMovableUnitsHaveMoved(state, playerName)) {
             switchTurn(state)
         }
     }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
@@ -444,96 +444,66 @@ class GameModelTest {
     }
 
     @Test
-    fun `triad outpost switches turn from first to second player`() {
+    fun `triad outpost turn stays after only one move`() {
 
         val roomRegistry = RoomRegistry()
         val gameService = GameService(CombatService())
 
-        val room = roomRegistry.createRoom(
-            GameMode.TRIAD_OUTPOST
-        )
+        val room = roomRegistry.createRoom(GameMode.TRIAD_OUTPOST)
 
-        gameService.handleJoin(
-            room.gameState,
-            "P1",
-            "session-1"
-        )
+        gameService.handleJoin(room.gameState, "P1", "session-1")
+        gameService.handleJoin(room.gameState, "P2", "session-2")
+        gameService.handleJoin(room.gameState, "P3", "session-3")
 
-        gameService.handleJoin(
-            room.gameState,
-            "P2",
-            "session-2"
-        )
+        assertEquals("P1", room.gameState.currentTurn)
 
-        gameService.handleJoin(
-            room.gameState,
-            "P3",
-            "session-3"
-        )
-
-        assertEquals(
-            "P1",
-            room.gameState.currentTurn
-        )
-
-        val move = Move(
-            player = "P1",
-            type = UnitType.INFANTRY,
-            fromX = 4,
-            fromY = 9,
-            toX = 4,
-            toY = 10
-        )
-
+        // P1 bewegt nur INFANTRY -- die anderen 2 Einheiten bleiben unbewegt.
         val state = gameService.handleMove(
             room.gameState,
-            move
+            Move(
+                player = "P1",
+                type = UnitType.INFANTRY,
+                fromX = 4,
+                fromY = 9,
+                toX = 4,
+                toY = 10
+            )
         )
 
-        assertEquals(
-            "P2",
-            state.currentTurn
-        )
+        // Turn bleibt bei P1, weil ARCHER und CAVALRY noch nicht gezogen haben.
+        assertEquals("P1", state.currentTurn)
     }
 
     @Test
-    fun `battlefield peaks switches turn from first to second player`() {
+    fun `battlefield peaks turn stays after only one move`() {
 
         val roomRegistry = RoomRegistry()
         val gameService = GameService(CombatService())
 
-        val room = roomRegistry.createRoom(
-            GameMode.BATTLEFIELD_PEAKS
-        )
+        val room = roomRegistry.createRoom(GameMode.BATTLEFIELD_PEAKS)
 
         gameService.handleJoin(room.gameState, "P1", "session-1")
         gameService.handleJoin(room.gameState, "P2", "session-2")
         gameService.handleJoin(room.gameState, "P3", "session-3")
         gameService.handleJoin(room.gameState, "P4", "session-4")
 
-        assertEquals(
-            "P1",
-            room.gameState.currentTurn
-        )
+        assertEquals("P1", room.gameState.currentTurn)
 
-        val move = Move(
-            player = "P1",
-            type = UnitType.INFANTRY,
-            fromX = 6,
-            fromY = 9,
-            toX = 6,
-            toY = 8
-        )
-
+        // P1-INFANTRY-Start: (6,9), Basis bei (6,10). Move zu (6,8) ist Border.
         val state = gameService.handleMove(
             room.gameState,
-            move
+            Move(
+                player = "P1",
+                type = UnitType.INFANTRY,
+                fromX = 6,
+                fromY = 9,
+                toX = 6,
+                toY = 8
+            )
         )
 
-        assertEquals(
-            "P2",
-            state.currentTurn
-        )
+        // Turn bleibt bei P1, weil ARCHER und CAVALRY noch nicht gezogen haben.
+        assertEquals("P1", state.currentTurn)
     }
 
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
@@ -506,4 +506,100 @@ class GameModelTest {
         assertEquals("P1", state.currentTurn)
     }
 
+    @Test
+    fun `triad outpost switches turn after all three units moved`() {
+
+        val roomRegistry = RoomRegistry()
+        val gameService = GameService(CombatService())
+
+        val room = roomRegistry.createRoom(GameMode.TRIAD_OUTPOST)
+
+        gameService.handleJoin(room.gameState, "P1", "session-1")
+        gameService.handleJoin(room.gameState, "P2", "session-2")
+        gameService.handleJoin(room.gameState, "P3", "session-3")
+
+        // P1-Start-Positionen (siehe GameService.startTriadOutpostGame):
+        //   ARCHER (5,8), INFANTRY (4,9), CAVALRY (6,9), Basis (5,9)
+        gameService.handleMove(
+            room.gameState,
+            Move("P1", UnitType.INFANTRY, 4, 9, 4, 10)
+        )
+        assertEquals("P1", room.gameState.currentTurn)
+
+        gameService.handleMove(
+            room.gameState,
+            Move("P1", UnitType.ARCHER, 5, 8, 5, 7)
+        )
+        assertEquals("P1", room.gameState.currentTurn)
+
+        // Mit dem dritten Move sollte der Auto-Switch greifen.
+        val state = gameService.handleMove(
+            room.gameState,
+            Move("P1", UnitType.CAVALRY, 6, 9, 6, 10)
+        )
+
+        assertEquals("P2", state.currentTurn)
+    }
+
+    @Test
+    fun `triad outpost endTurn forces switch with units remaining`() {
+
+        val roomRegistry = RoomRegistry()
+        val gameService = GameService(CombatService())
+
+        val room = roomRegistry.createRoom(GameMode.TRIAD_OUTPOST)
+
+        gameService.handleJoin(room.gameState, "P1", "session-1")
+        gameService.handleJoin(room.gameState, "P2", "session-2")
+        gameService.handleJoin(room.gameState, "P3", "session-3")
+
+        // P1 bewegt nur INFANTRY, ARCHER und CAVALRY bleiben.
+        gameService.handleMove(
+            room.gameState,
+            Move("P1", UnitType.INFANTRY, 4, 9, 4, 10)
+        )
+        assertEquals("P1", room.gameState.currentTurn)
+
+        // Trotz unbewegter Einheiten beendet P1 manuell seinen Zug.
+        val state = gameService.endTurn(room.gameState, "P1")
+
+        assertEquals("P2", state.currentTurn)
+    }
+
+    @Test
+    fun `battlefield peaks switches turn after all three units moved`() {
+
+        val roomRegistry = RoomRegistry()
+        val gameService = GameService(CombatService())
+
+        val room = roomRegistry.createRoom(GameMode.BATTLEFIELD_PEAKS)
+
+        gameService.handleJoin(room.gameState, "P1", "session-1")
+        gameService.handleJoin(room.gameState, "P2", "session-2")
+        gameService.handleJoin(room.gameState, "P3", "session-3")
+        gameService.handleJoin(room.gameState, "P4", "session-4")
+
+        // P1-Start-Positionen (siehe GameService.startBattlefieldPeaksGame):
+        //   ARCHER (5,9), INFANTRY (6,9), CAVALRY (7,9), Basis (6,10)
+        gameService.handleMove(
+            room.gameState,
+            Move("P1", UnitType.INFANTRY, 6, 9, 6, 8)
+        )
+        assertEquals("P1", room.gameState.currentTurn)
+
+        gameService.handleMove(
+            room.gameState,
+            Move("P1", UnitType.ARCHER, 5, 9, 5, 10)
+        )
+        assertEquals("P1", room.gameState.currentTurn)
+
+        // Mit dem dritten Move sollte der Auto-Switch greifen.
+        val state = gameService.handleMove(
+            room.gameState,
+            Move("P1", UnitType.CAVALRY, 7, 9, 7, 10)
+        )
+
+        assertEquals("P2", state.currentTurn)
+    }
+
 }


### PR DESCRIPTION
## Fix: Turn-Switch in TRIAD/BATTLEFIELD greift sofort nach erstem Move

### Was

`finishMove` switcht jetzt in allen 3 Modi erst, wenn alle bewegbaren Einheiten gezogen haben — vorher haben TRIAD und BATTLEFIELD den Turn schon nach dem 1. Move gewechselt.

### Warum

Spec sagt: Spieler darf jede seiner Einheiten max. einmal pro Zug bewegen, muss aber nicht alle bewegen. Vorzeitig kann er via `/end-turn` abbrechen. DUAL_VALLEY hatte das korrekt — die anderen Modi nicht.

### Änderungen

- `GameService.finishMove`: modus-spezifischer `if/else`-Branch raus, immer `allMovableUnitsHaveMoved`-Check
- 2 bestehende Tests umgestellt (asserteten das Bug-Verhalten)
- 3 neue Tests: Multi-Move + endTurn-Forcing für TRIAD/BATTLEFIELD

### Tests

26/26 grün in `GameModelTest`, alle bestehenden Tests unverändert grün.

