### PR TITLE
Fix/end turn dto consistency

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -1,5 +1,6 @@
 package at.aau.hexabrawl.websocketserver.controller
 
+import at.aau.hexabrawl.websocketserver.model.EndTurnRequest
 import at.aau.hexabrawl.websocketserver.model.ErrorCode
 import at.aau.hexabrawl.websocketserver.model.ErrorMessage
 import at.aau.hexabrawl.websocketserver.model.GameService
@@ -162,7 +163,7 @@ class WebSocketBrokerController(
     @MessageMapping("/rooms/{roomId}/end-turn")
     fun endTurnRoom(
         @DestinationVariable roomId: String,
-        playerName: String,
+        request: EndTurnRequest,
         headerAccessor: SimpMessageHeaderAccessor
     ): GameState? {
         val sessionId = headerAccessor.sessionId ?: ""
@@ -180,12 +181,12 @@ class WebSocketBrokerController(
             return null
         }
 
-        if (stateBefore.currentTurn != playerName) {
+        if (stateBefore.currentTurn != request.playerName) {
             sendError(sessionId, ErrorCode.NOT_YOUR_TURN, "Du kannst nicht die Runde eines anderen Spielers beenden!")
             return null
         }
 
-        val state = gameService.endTurn(room.gameState, playerName)
+        val state = gameService.endTurn(room.gameState, request.playerName)
         sendRoomState(roomId, state)
         return state
     }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/EndTurnRequest.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/EndTurnRequest.kt
@@ -1,0 +1,14 @@
+package at.aau.hexabrawl.websocketserver.model
+
+/**
+ * DTO für den End-Turn-Request des Clients.
+ *
+ * Wird als JSON ueber STOMP an /app/rooms/{roomId}/end-turn gesendet:
+ *   { "playerName": "Alice" }
+ *
+ * Spring/Jackson deserialisiert das automatisch in diese data class.
+ * Default ist Gson-Krueke fuer die Reflection-basierte Deserialisierung.
+ */
+data class EndTurnRequest(
+    val playerName: String = ""
+)


### PR DESCRIPTION
## EndTurn: Roh-String → DTO

`/rooms/{roomId}/end-turn` nimmt jetzt `EndTurnRequest` statt einem
Roh-String entgegen — damit kommt der App-seitige JSON-Body
`{"playerName": "Alice"}` sauber an.

Vorher: Spring kippte den ganzen JSON-Body in den String-Parameter,
`currentTurn != playerName` matched nie → ständig `NOT_YOUR_TURN`-Error.

### Änderungen
- Neue `EndTurnRequest.kt` (DTO)
- `endTurnRoom` nimmt `EndTurnRequest` statt `String`
