### PR TITLE
Feat/remove starting units

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -117,27 +117,8 @@ class GameService(
         val p1 = state.players[0]
         val p2 = state.players[1]
 
-        val startPositionsP1 = listOf(
-            Pair(1, 2),  // ARCHER  (linker Nachbar der Basis)
-            Pair(2, 3),  // INFANTRY (unterer Nachbar)
-            Pair(3, 2)   // CAVALRY  (rechter Nachbar)
-        )
-
-        val startPositionsP2 = listOf(
-            Pair(8, 7),  // ARCHER
-            Pair(7, 8),  // INFANTRY
-            Pair(6, 7)   // CAVALRY
-        )
-
-        UnitType.entries
-            .filter { it != UnitType.SKELETON && it != UnitType.BASE }
-            .forEachIndexed { index, type ->
-                val (x1, y1) = startPositionsP1[index]
-                val (x2, y2) = startPositionsP2[index]
-                state.units.add(GameUnit(p1.name, x1, y1, type))
-                state.units.add(GameUnit(p2.name, x2, y2, type))
-            }
-
+        // Nur Basen platzieren -- Kampfeinheiten kaufen die Spieler ueber
+        // den Buy-Unit-Endpoint, sobald sie genug Gold haben.
         state.units.add(GameUnit(p1.name, BASE_POSITION_P1.first, BASE_POSITION_P1.second, UnitType.BASE))
         state.units.add(GameUnit(p2.name, BASE_POSITION_P2.first, BASE_POSITION_P2.second, UnitType.BASE))
 
@@ -161,21 +142,7 @@ class GameService(
             Pair(9, 3)   // P3 Nordosten
         )
 
-        val startPositionsP1 = listOf(Pair(5, 8), Pair(4, 9), Pair(6, 9))   // Einheiten um P1-Basis
-        val startPositionsP2 = listOf(Pair(2, 3), Pair(2, 4), Pair(1, 4))   // Einheiten um P2-Basis
-        val startPositionsP3 = listOf(Pair(8, 3), Pair(8, 4), Pair(9, 4))   // Einheiten um P3-Basis
-
-        UnitType.entries
-            .filter { it != UnitType.SKELETON && it != UnitType.BASE }
-            .forEachIndexed { index, type ->
-                val (x1, y1) = startPositionsP1[index]
-                val (x2, y2) = startPositionsP2[index]
-                val (x3, y3) = startPositionsP3[index]
-                state.units.add(GameUnit(p1.name, x1, y1, type))
-                state.units.add(GameUnit(p2.name, x2, y2, type))
-                state.units.add(GameUnit(p3.name, x3, y3, type))
-            }
-
+        // Nur Basen platzieren -- Kampfeinheiten werden ueber Buy-Unit gekauft.
         listOf(p1 to bases[0], p2 to bases[1], p3 to bases[2]).forEach { (p, base) ->
             state.units.add(GameUnit(p.name, base.first, base.second, UnitType.BASE))
         }
@@ -206,24 +173,7 @@ class GameService(
             Pair(6,  2)   // P4 Nord
         )
 
-        val startPositionsP1 = listOf(Pair(5, 9), Pair(6, 9), Pair(7, 9))   // Einheiten um P1-Basis
-        val startPositionsP2 = listOf(Pair(2, 5), Pair(3, 5), Pair(3, 6))   // Einheiten um P2-Basis
-        val startPositionsP3 = listOf(Pair(10, 5), Pair(9, 5), Pair(9, 6))  // Einheiten um P3-Basis
-        val startPositionsP4 = listOf(Pair(5, 2), Pair(6, 3), Pair(7, 2))   // Einheiten um P4-Basis
-
-        UnitType.entries
-            .filter { it != UnitType.SKELETON && it != UnitType.BASE }
-            .forEachIndexed { index, type ->
-                val (x1, y1) = startPositionsP1[index]
-                val (x2, y2) = startPositionsP2[index]
-                val (x3, y3) = startPositionsP3[index]
-                val (x4, y4) = startPositionsP4[index]
-                state.units.add(GameUnit(p1.name, x1, y1, type))
-                state.units.add(GameUnit(p2.name, x2, y2, type))
-                state.units.add(GameUnit(p3.name, x3, y3, type))
-                state.units.add(GameUnit(p4.name, x4, y4, type))
-            }
-
+        // Nur Basen platzieren -- Kampfeinheiten werden ueber Buy-Unit gekauft.
         listOf(p1 to bases[0], p2 to bases[1], p3 to bases[2], p4 to bases[3]).forEach { (p, base) ->
             state.units.add(GameUnit(p.name, base.first, base.second, UnitType.BASE))
         }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -28,6 +28,20 @@ class WebSocketBrokerControllerTest {
         `when`(headerAccessor.sessionId).thenReturn("test-session")
     }
 
+    /**
+     * Helper: platziert ARCHER/INFANTRY/CAVALRY fuer beide DUAL_VALLEY-Spieler
+     * auf den klassischen Test-Positionen. Wird seit dem Entfernen der
+     * Start-Einheiten benoetigt, um Move-/Combat-Tests sauber aufzusetzen.
+     */
+    private fun seedDualValleyCombatUnits(state: GameState, p1: String, p2: String) {
+        state.units.add(GameUnit(p1, 1, 2, UnitType.ARCHER))
+        state.units.add(GameUnit(p1, 2, 3, UnitType.INFANTRY))
+        state.units.add(GameUnit(p1, 3, 2, UnitType.CAVALRY))
+        state.units.add(GameUnit(p2, 8, 7, UnitType.ARCHER))
+        state.units.add(GameUnit(p2, 7, 8, UnitType.INFANTRY))
+        state.units.add(GameUnit(p2, 6, 7, UnitType.CAVALRY))
+    }
+
     @Test
     fun `player can join game`() {
         val state = controller.handleJoin("Josef", "session-1")
@@ -50,12 +64,9 @@ class WebSocketBrokerControllerTest {
 
         assertEquals(2, state.players.size)
         assertNotNull(state.currentTurn)
-        // 3 regulaere Einheiten (ARCHER, INFANTRY, CAVALRY) + 1 BASE pro Spieler = 8 Units total.
-        assertEquals(8, state.units.size)
-        assertTrue(state.units.any { it.type == UnitType.ARCHER })
-        assertTrue(state.units.any { it.type == UnitType.INFANTRY })
-        assertTrue(state.units.any { it.type == UnitType.CAVALRY })
-        assertTrue(state.units.any { it.type == UnitType.BASE })
+        // Spieler starten nur mit Basis -- Kampfeinheiten werden gekauft.
+        assertEquals(2, state.units.size)
+        assertTrue(state.units.all { it.type == UnitType.BASE })
         assertEquals(GameStatus.IN_PROGRESS, state.status)
     }
 
@@ -81,6 +92,7 @@ class WebSocketBrokerControllerTest {
     fun `wrong player cannot move`() {
         controller.handleJoin("Josef", "session-1")
         controller.handleJoin("Sebastian", "session-2")
+        seedDualValleyCombatUnits(gameService.gameState, "Josef", "Sebastian")
 
         val move = Move("Sebastian", UnitType.INFANTRY, 5, 5, 6, 6)
 
@@ -94,6 +106,7 @@ class WebSocketBrokerControllerTest {
     fun `player can move and turn switches`() {
         controller.handleJoin("Josef", "session-1")
         controller.handleJoin("Sebastian", "session-2")
+        seedDualValleyCombatUnits(gameService.gameState, "Josef", "Sebastian")
 
         // Mit Rundensystem switcht der Turn erst wenn alle bewegbaren Einheiten
         // (ARCHER, INFANTRY, CAVALRY) des Spielers gezogen haben.
@@ -144,6 +157,7 @@ class WebSocketBrokerControllerTest {
     fun `multiple moves update unit positions correctly`() {
         controller.handleJoin("Alice", "session-1")
         controller.handleJoin("Bob", "session-2")
+        seedDualValleyCombatUnits(gameService.gameState, "Alice", "Bob")
 
         // Gold geben, damit sie nach der Runde nicht pleitegehen
         gameService.getCurrentState().players.forEach { it.gold = 100 }
@@ -176,6 +190,7 @@ class WebSocketBrokerControllerTest {
     fun `move does nothing when wrong player`() {
         controller.handleJoin("Alice", "session-1")
         controller.handleJoin("Bob", "session-2")
+        seedDualValleyCombatUnits(gameService.gameState, "Alice", "Bob")
 
         val result = controller.handleMove(Move("Bob", UnitType.INFANTRY, 7, 8, 7, 6))
 
@@ -231,6 +246,7 @@ class WebSocketBrokerControllerTest {
     fun `turn switches after valid move`() {
         controller.handleJoin("Alice", "session-1")
         controller.handleJoin("Bob", "session-2")
+        seedDualValleyCombatUnits(gameService.gameState, "Alice", "Bob")
 
         // Gold geben, damit sie nach der Runde nicht pleitegehen
         gameService.getCurrentState().players.forEach { it.gold = 100 }
@@ -530,6 +546,8 @@ class WebSocketBrokerControllerTest {
             headerAccessor
         )
 
+        seedDualValleyCombatUnits(room.gameState, "Alice", "Bob")
+
         val move = Move(
             player = "Alice",
             type = UnitType.INFANTRY,
@@ -575,6 +593,8 @@ class WebSocketBrokerControllerTest {
             JoinRequest(name = "Bob"),
             headerAccessor
         )
+
+        seedDualValleyCombatUnits(room.gameState, "Alice", "Bob")
 
         // Alle 3 bewegbaren Einheiten bewegen damit der Turn switcht.
         controller.moveRoom(room.roomId, Move("Alice", UnitType.ARCHER, 1, 2, 1, 3), headerAccessor)
@@ -762,6 +782,7 @@ class WebSocketBrokerControllerTest {
             "Marie",
             "session-2"
         )
+        seedDualValleyCombatUnits(room.gameState, "Josef", "Marie")
 
         val move = Move(
             player = "Josef",
@@ -1193,6 +1214,7 @@ class WebSocketBrokerControllerTest {
     fun `move further than 2 hex fields is rejected`() {
         controller.handleJoin("Alice", "session-1")
         controller.handleJoin("Bob", "session-2")
+        seedDualValleyCombatUnits(gameService.gameState, "Alice", "Bob")
 
         // Alice INFANTRY steht auf (2, 3), Versuch auf (2, 8) - viel zu weit.
         val move = Move("Alice", UnitType.INFANTRY, 2, 3, 2, 8)
@@ -1211,6 +1233,7 @@ class WebSocketBrokerControllerTest {
     fun `move exactly 2 hex fields is accepted`() {
         controller.handleJoin("Alice", "session-1")
         controller.handleJoin("Bob", "session-2")
+        seedDualValleyCombatUnits(gameService.gameState, "Alice", "Bob")
 
         // Alice bewegt alle 3 Einheiten - INFANTRY genau 2 Hex weit.
         controller.handleMove(Move("Alice", UnitType.ARCHER, 1, 2, 1, 3))

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/integration/MultiRoomIntegrationTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/integration/MultiRoomIntegrationTest.kt
@@ -82,6 +82,12 @@ class MultiRoomIntegrationTest {
             roomB.gameState.status
         )
 
+        // Combat-Units in Raum A manuell platzieren (Start-Einheiten werden
+        // seit dem Wirtschaftssystem-Umbau nicht mehr automatisch gesetzt).
+        roomA.gameState.units.add(GameUnit("Josef", 1, 2, UnitType.ARCHER))
+        roomA.gameState.units.add(GameUnit("Josef", 2, 3, UnitType.INFANTRY))
+        roomA.gameState.units.add(GameUnit("Josef", 3, 2, UnitType.CAVALRY))
+
         //State-Leak-Test
         val unitsBefore = roomB.gameState.units.map {
             GameUnit(

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerTest.kt
@@ -67,6 +67,14 @@ class DisconnectHandlerTest {
     fun `disconnect only removes disconnected player units`() {
         gameService.handleJoin("Alice", "session-1")
         gameService.handleJoin("Bob", "session-2")
+        // Combat-Units manuell platzieren (Start-Einheiten werden nicht mehr automatisch gesetzt).
+        val s = gameService.gameState
+        s.units.add(GameUnit("Alice", 1, 2, UnitType.ARCHER))
+        s.units.add(GameUnit("Alice", 2, 3, UnitType.INFANTRY))
+        s.units.add(GameUnit("Alice", 3, 2, UnitType.CAVALRY))
+        s.units.add(GameUnit("Bob", 8, 7, UnitType.ARCHER))
+        s.units.add(GameUnit("Bob", 7, 8, UnitType.INFANTRY))
+        s.units.add(GameUnit("Bob", 6, 7, UnitType.CAVALRY))
 
         gameService.handleDisconnect("session-1")
 

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConquestTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConquestTest.kt
@@ -13,6 +13,15 @@ class FieldConquestTest {
         gameService = GameService(CombatService())
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        // Standard-Combat-Units platzieren (seit Entfernen der Start-Einheiten
+        // werden die nicht mehr automatisch vom Server gesetzt).
+        val state = gameService.gameState
+        state.units.add(GameUnit("Alice", 1, 2, UnitType.ARCHER))
+        state.units.add(GameUnit("Alice", 2, 3, UnitType.INFANTRY))
+        state.units.add(GameUnit("Alice", 3, 2, UnitType.CAVALRY))
+        state.units.add(GameUnit("Bob", 8, 7, UnitType.ARCHER))
+        state.units.add(GameUnit("Bob", 7, 8, UnitType.INFANTRY))
+        state.units.add(GameUnit("Bob", 6, 7, UnitType.CAVALRY))
     }
 
     @Test

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
@@ -142,6 +142,8 @@ class GameModelTest {
 
         gameService.handleJoin(state1, "Josef", "s1")
         gameService.handleJoin(state1, "Marie", "s2")
+        // Combat-Units manuell platzieren (Start-Einheiten werden nicht mehr automatisch gesetzt).
+        state1.units.add(GameUnit("Josef", 2, 3, UnitType.INFANTRY))
 
         val move = Move(
             "Josef",
@@ -172,6 +174,8 @@ class GameModelTest {
 
         gameService.handleJoin("Josef", "s1")
         gameService.handleJoin("Marie", "s2")
+        // Combat-Units manuell platzieren
+        gameService.gameState.units.add(GameUnit("Josef", 2, 3, UnitType.INFANTRY))
 
         val move = Move(
             "Josef",
@@ -517,6 +521,10 @@ class GameModelTest {
         gameService.handleJoin(room.gameState, "P1", "session-1")
         gameService.handleJoin(room.gameState, "P2", "session-2")
         gameService.handleJoin(room.gameState, "P3", "session-3")
+        // Combat-Units manuell platzieren (werden nicht mehr automatisch gesetzt).
+        room.gameState.units.add(GameUnit("P1", 5, 8, UnitType.ARCHER))
+        room.gameState.units.add(GameUnit("P1", 4, 9, UnitType.INFANTRY))
+        room.gameState.units.add(GameUnit("P1", 6, 9, UnitType.CAVALRY))
 
         // P1-Start-Positionen (siehe GameService.startTriadOutpostGame):
         //   ARCHER (5,8), INFANTRY (4,9), CAVALRY (6,9), Basis (5,9)
@@ -578,6 +586,10 @@ class GameModelTest {
         gameService.handleJoin(room.gameState, "P2", "session-2")
         gameService.handleJoin(room.gameState, "P3", "session-3")
         gameService.handleJoin(room.gameState, "P4", "session-4")
+        // Combat-Units manuell platzieren
+        room.gameState.units.add(GameUnit("P1", 5, 9, UnitType.ARCHER))
+        room.gameState.units.add(GameUnit("P1", 6, 9, UnitType.INFANTRY))
+        room.gameState.units.add(GameUnit("P1", 7, 9, UnitType.CAVALRY))
 
         // P1-Start-Positionen (siehe GameService.startBattlefieldPeaksGame):
         //   ARCHER (5,9), INFANTRY (6,9), CAVALRY (7,9), Basis (6,10)

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/UnitTypeTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/UnitTypeTest.kt
@@ -148,6 +148,12 @@ class UnitTypeTest {
 
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        // Combat-Units manuell platzieren (werden seit Entfernung der
+        // Start-Einheiten nicht mehr automatisch gesetzt).
+        val s = gameService.gameState
+        s.units.add(GameUnit("Alice", 1, 2, UnitType.ARCHER))
+        s.units.add(GameUnit("Alice", 2, 3, UnitType.INFANTRY))
+        s.units.add(GameUnit("Alice", 3, 2, UnitType.CAVALRY))
 
         val stateBefore = gameService.getCurrentState()
 
@@ -173,6 +179,8 @@ class UnitTypeTest {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        // Combat-Units manuell platzieren
+        gameService.gameState.units.add(GameUnit("Alice", 2, 3, UnitType.INFANTRY))
 
         val move = Move("Alice", UnitType.ARCHER, 2, 3, 2, 4) // kein ARCHER bei (2,3) - nur INFANTRY
 
@@ -191,6 +199,10 @@ class UnitTypeTest {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        // Combat-Units manuell platzieren
+        val s = gameService.gameState
+        s.units.add(GameUnit("Alice", 3, 2, UnitType.INFANTRY))
+        s.units.add(GameUnit("Bob", 6, 5, UnitType.INFANTRY))
 
         val alice = gameService.getCurrentState().units.first {
             it.player == "Alice" && it.type == UnitType.INFANTRY

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -12,6 +12,22 @@ class GameServiceTest {
         gameService = GameService(CombatService())
     }
 
+    /**
+     * Helper: platziert die klassischen Kampfeinheiten (ARCHER/INFANTRY/CAVALRY)
+     * fuer beide DUAL_VALLEY-Spieler. Seit Entfernung der automatischen
+     * Start-Einheiten muessen Tests die selber adden, wenn sie Move-/Combat-
+     * Verhalten testen wollen.
+     */
+    private fun seedDualValleyCombatUnits() {
+        val s = gameService.gameState
+        s.units.add(GameUnit("Alice", 1, 2, UnitType.ARCHER))
+        s.units.add(GameUnit("Alice", 2, 3, UnitType.INFANTRY))
+        s.units.add(GameUnit("Alice", 3, 2, UnitType.CAVALRY))
+        s.units.add(GameUnit("Bob", 8, 7, UnitType.ARCHER))
+        s.units.add(GameUnit("Bob", 7, 8, UnitType.INFANTRY))
+        s.units.add(GameUnit("Bob", 6, 7, UnitType.CAVALRY))
+    }
+
     @Test
     fun `test duplicate join and max players`() {
         // 1. Erster Join
@@ -25,6 +41,7 @@ class GameServiceTest {
 
         // 3. Zweiter Spieler
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
         assertThat(gameService.getCurrentState().status).isEqualTo(GameStatus.IN_PROGRESS)
 
         // 4. Dritter Spieler (Charlie) -> Darf nicht rein (MAX_PLAYERS = 2)
@@ -49,6 +66,7 @@ class GameServiceTest {
 
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
 
         val aliceBefore = gameService.getCurrentState().units.first {
             it.player == "Alice" && it.type == UnitType.INFANTRY
@@ -110,6 +128,7 @@ class GameServiceTest {
         // 1. Initialisierung prüfen (Branch: WAITING_FOR_PLAYERS -> IN_PROGRESS)
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
         val stateAfterJoin = gameService.getCurrentState()
         assertThat(stateAfterJoin.players).hasSize(2)
 
@@ -148,6 +167,7 @@ class GameServiceTest {
     fun `test combat removes losing unit and winner advances`() {
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
         val aliceInfantry = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
@@ -176,6 +196,7 @@ class GameServiceTest {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
 
         // Beide Basen kuenstlich entfernen, danach normaler Move ausfuehren -
         // checkWinCondition muss 0 Basen erkennen und Draw setzen.
@@ -201,6 +222,7 @@ class GameServiceTest {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
         val aliceInfantry = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
@@ -234,6 +256,7 @@ class GameServiceTest {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
         val aliceArcher = state.units.first { it.player == "Alice" && it.type == UnitType.ARCHER }
@@ -259,6 +282,7 @@ class GameServiceTest {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
         val bases = state.units.filter { it.type == UnitType.BASE }
@@ -279,6 +303,7 @@ class GameServiceTest {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
         val aliceBase = state.units.first { it.player == "Alice" && it.type == UnitType.BASE }
@@ -310,6 +335,7 @@ class GameServiceTest {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
         val regularTypes = listOf(UnitType.ARCHER, UnitType.INFANTRY, UnitType.CAVALRY)
@@ -327,6 +353,7 @@ class GameServiceTest {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
         val aliceInfantry = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
@@ -366,6 +393,7 @@ class GameServiceTest {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
 
@@ -424,6 +452,7 @@ class GameServiceTest {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
         state.players.forEach { it.gold = 20 }
@@ -448,6 +477,7 @@ class GameServiceTest {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
         state.players.forEach { it.gold = 12 }
@@ -470,6 +500,7 @@ class GameServiceTest {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
         state.players.first { it.name == "Alice" }.gold = 11
@@ -501,6 +532,7 @@ class GameServiceTest {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
         state.players.first { it.name == "Alice" }.gold = 5
@@ -524,6 +556,7 @@ class GameServiceTest {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
         val alice = state.players.first { it.name == "Alice" }
@@ -544,6 +577,7 @@ class GameServiceTest {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
         val alice = state.players.first { it.name == "Alice" }
@@ -560,6 +594,7 @@ class GameServiceTest {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
+        seedDualValleyCombatUnits()
         val state = gameService.getCurrentState()
         val alice = state.players.first { it.name == "Alice" }
         val bob = state.players.first { it.name == "Bob" }


### PR DESCRIPTION
# Start-Einheiten entfernen

Spieler starten jetzt nur noch mit ihrer Basis und 7 Startfeldern.
Kampfeinheiten (ARCHER/INFANTRY/CAVALRY) müssen über den Buy-Unit-
Endpoint gekauft werden.

### Änderungen

**`GameService.kt`** — in allen drei Mode-Start-Methoden
(`startDualValleyGame`, `startTriadOutpostGame`, `startBattlefieldPeaksGame`)
wird der Loop entfernt, der ARCHER/INFANTRY/CAVALRY platziert hat. Basen
und Startgebiete bleiben unverändert.

**Tests** — in 7 Test-Files werden die Kampfeinheiten jetzt manuell vor
Move-/Combat-Tests platziert (`state.units.add(...)`). Wo handleJoin
früher implizit Start-Units gebracht hat, muss der Test sie jetzt
selbst seeden.

Es wurden deshalb 8 Datein geändert, da die Logik in machen Test umgeschrieben werden mussten


Jetzt können die Kaufendpunkte implementiert werden