### PR TITLE
Feat #131: Room-scoped Buy-Farm Endpoint und Einkommens-Logik implementieren

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -200,22 +200,41 @@ class WebSocketBrokerController(
 
         val room = roomRegistry.findById(roomId)
         if (room == null) {
-            sendError(sessionId, ErrorCode.ROOM_NOT_FOUND, ROOM_NOT_FOUND_MESSAGE)
+            sendError(sessionId, ErrorCode.ROOM_NOT_FOUND, "Raum nicht gefunden.")
             return null
         }
 
         val state = room.gameState
-        val player = state.players.find { it.sessionId == sessionId } ?: return null
 
-        val cost = GameService.FARM_BASE_COST + (player.farms * GameService.FARM_COST_INCREMENT)
-        if (player.gold < cost) {
-            sendError(sessionId, ErrorCode.INSUFFICIENT_GOLD, "Nicht genug Gold für eine Farm!")
+        if (state.status != GameStatus.IN_PROGRESS) {
+            sendError(sessionId, ErrorCode.GAME_NOT_STARTED, "Spiel ist nicht gestartet.")
             return null
         }
 
-        val updated = gameService.buyFarm(state, player.name)
-        sendRoomState(roomId, updated)
-        return updated
+        val player = state.players.find { it.sessionId == sessionId }
+        if (player == null) return null
+
+        if (state.currentTurn != player.name) {
+            sendError(sessionId, ErrorCode.NOT_YOUR_TURN, "Du bist nicht am Zug.")
+            return null
+        }
+
+        val cost = GameService.FARM_BASE_COST + (player.farms * GameService.FARM_COST_INCREMENT)
+
+        if (player.gold < cost) {
+            sendError(sessionId, ErrorCode.INSUFFICIENT_GOLD, "Nicht genug Gold.")
+            return null
+        }
+
+        // Werte direkt hier updaten
+        synchronized(state.lock) {
+            player.gold -= cost
+            player.farms += 1
+            player.income = player.farms * GameService.FARM_INCOME_PER_ROUND
+        }
+
+        messagingTemplate.convertAndSend("/topic/rooms/$roomId/state", state)
+        return state
     }
 
     // Bridges fuer Tests, die noch ueber den globalen GameState gehen.

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -514,25 +514,4 @@ class GameService(
 
         checkWinCondition(state)
     }
-
-    /**
-     * Kauft eine Farm fuer den Spieler (#60).
-     * Preis: FARM_BASE_COST + farms * FARM_COST_INCREMENT (10, 11, 12, ...).
-     */
-    fun buyFarm(state: GameState, playerName: String): GameState = synchronized(state.lock) {
-        if (state.status != GameStatus.IN_PROGRESS) return state
-
-        val player = state.players.find { it.name == playerName } ?: return state
-
-        val cost = FARM_BASE_COST + (player.farms * FARM_COST_INCREMENT)
-
-        if (player.gold >= cost) {
-            player.gold -= cost
-            player.farms += 1
-            println("Service: $playerName kaufte Farm für $cost. (Total: ${player.farms})")
-        } else {
-            println("Service: $playerName hat zu wenig Gold ($cost) für Farm.")
-        }
-        return state
-    }
 }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Player.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Player.kt
@@ -6,5 +6,6 @@ data class Player (
     val sessionId : String = "",
     val color: PlayerColor = PlayerColor.RED,
     var gold: Int = 0,
-    var farms: Int = 0
+    var farms: Int = 0,
+    var income: Int = 0
 ){}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -1046,81 +1046,80 @@ class WebSocketBrokerControllerTest {
             )
     }
 
-    // ---- Buy-Farm-Tests (#60, portiert von /buyFarm auf /rooms/{id}/buy-farm) ----
+    // ---- Tests fuer Sub-Issue #131 (Buy-Farm Room-Endpoint) ----
 
     @Test
-    fun `buyFarmRoom returns updated state when gold is sufficient`() {
+    fun `buyFarmRoom happy path increases farms and calculates new price`() {
         val room = roomRegistry.createRoom(GameMode.DUAL_VALLEY)
+        room.gameState.status = GameStatus.IN_PROGRESS
+        val alice = Player("Alice", "test-session", gold = 25, farms = 0)
+        room.gameState.players.add(alice)
+        room.gameState.currentTurn = "Alice"
 
-        controller.joinRoom(
-            room.roomId,
-            JoinRequest(name = "Alice", color = PlayerColor.RED),
-            headerAccessor
-        )
-        val secondHeaderAccessor = mock(SimpMessageHeaderAccessor::class.java)
-        `when`(secondHeaderAccessor.sessionId).thenReturn("session-2")
-        controller.joinRoom(
-            room.roomId,
-            JoinRequest(name = "Bob", color = PlayerColor.BLUE),
-            secondHeaderAccessor
-        )
+        val result1 = controller.buyFarmRoom(room.roomId, headerAccessor)!!
+        assertEquals(1, alice.farms)
+        assertEquals(15, alice.gold)
+        assertEquals(3, alice.income)
+        verify(messagingTemplate).convertAndSend(eq("/topic/rooms/${room.roomId}/state"), eq(result1))
 
-        val alice = room.gameState.players.first { it.name == "Alice" }
-        alice.gold = 20  // genug Gold
-
-        val result = controller.buyFarmRoom(room.roomId, headerAccessor)
-
-        assertNotNull(result)
-        assertEquals(1, result?.players?.first { it.name == "Alice" }?.farms)
-        // 20 - FARM_BASE_COST(10) = 10
-        assertEquals(10, result?.players?.first { it.name == "Alice" }?.gold)
+        val result2 = controller.buyFarmRoom(room.roomId, headerAccessor)!!
+        assertEquals(2, alice.farms)
+        assertEquals(4, alice.gold)
+        assertEquals(6, alice.income)
     }
 
     @Test
-    fun `buyFarmRoom sends INSUFFICIENT_GOLD error when poor`() {
-        val room = roomRegistry.createRoom(GameMode.DUAL_VALLEY)
-
-        controller.joinRoom(
-            room.roomId,
-            JoinRequest(name = "Alice", color = PlayerColor.RED),
-            headerAccessor
-        )
-        val secondHeaderAccessor = mock(SimpMessageHeaderAccessor::class.java)
-        `when`(secondHeaderAccessor.sessionId).thenReturn("session-2")
-        controller.joinRoom(
-            room.roomId,
-            JoinRequest(name = "Bob", color = PlayerColor.BLUE),
-            secondHeaderAccessor
-        )
-
-        val alice = room.gameState.players.first { it.name == "Alice" }
-        alice.gold = 5  // zu wenig fuer Farm (Kosten 10)
-
-        val result = controller.buyFarmRoom(room.roomId, headerAccessor)
-
+    fun `buyFarmRoom sends ROOM_NOT_FOUND if room does not exist`() {
+        val result = controller.buyFarmRoom("invalid-id", headerAccessor)
         assertNull(result)
         verify(messagingTemplate).convertAndSendToUser(
-            eq("test-session"),
-            eq("/queue/errors"),
-            argThat { it is ErrorMessage && it.errorCode == ErrorCode.INSUFFICIENT_GOLD }
+            eq("test-session"), eq("/queue/errors"),
+            argThat { it is ErrorMessage && it.errorCode == ErrorCode.ROOM_NOT_FOUND }
         )
     }
 
     @Test
-    fun `buyFarmRoom returns null if player session is unknown`() {
+    fun `buyFarmRoom sends GAME_NOT_STARTED if status is WAITING`() {
         val room = roomRegistry.createRoom(GameMode.DUAL_VALLEY)
-        // Niemand beigetreten -> headerAccessor.sessionId ist "test-session", kein Match
+        room.gameState.players.add(Player("Alice", "test-session"))
         val result = controller.buyFarmRoom(room.roomId, headerAccessor)
         assertNull(result)
     }
 
     @Test
-    fun `buyFarmRoom handles null sessionId from headerAccessor gracefully`() {
+    fun `buyFarmRoom sends NOT_YOUR_TURN if player is not currentTurn`() {
         val room = roomRegistry.createRoom(GameMode.DUAL_VALLEY)
-        val localHeaderAccessor = mock(SimpMessageHeaderAccessor::class.java)
-        `when`(localHeaderAccessor.sessionId).thenReturn(null)
+        room.gameState.status = GameStatus.IN_PROGRESS
+        room.gameState.players.add(Player("Alice", "test-session"))
+        room.gameState.currentTurn = "Bob"
+        val result = controller.buyFarmRoom(room.roomId, headerAccessor)
+        assertNull(result)
+    }
 
-        val result = controller.buyFarmRoom(room.roomId, localHeaderAccessor)
+    @Test
+    fun `buyFarmRoom sends INSUFFICIENT_GOLD if player cannot afford farm`() {
+        val room = roomRegistry.createRoom(GameMode.DUAL_VALLEY)
+        room.gameState.status = GameStatus.IN_PROGRESS
+        room.gameState.currentTurn = "Alice"
+        room.gameState.players.add(Player("Alice", "test-session", gold = 9))
+        val result = controller.buyFarmRoom(room.roomId, headerAccessor)
+        assertNull(result)
+    }
+
+    @Test
+    fun `buyFarmRoom returns null if player is not found in room`() {
+        val room = roomRegistry.createRoom(GameMode.DUAL_VALLEY)
+        room.gameState.status = GameStatus.IN_PROGRESS
+        val result = controller.buyFarmRoom(room.roomId, headerAccessor)
+        assertNull(result)
+    }
+
+    @Test
+    fun `buyFarmRoom handles missing sessionId gracefully`() {
+        val emptyAccessor = mock(SimpMessageHeaderAccessor::class.java)
+        `when`(emptyAccessor.sessionId).thenReturn(null)
+        val room = roomRegistry.createRoom(GameMode.DUAL_VALLEY)
+        val result = controller.buyFarmRoom(room.roomId, emptyAccessor)
         assertNull(result)
     }
 

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -552,44 +552,6 @@ class GameServiceTest {
     }
 
     @Test
-    fun `test buyFarm - erfolgreicher Kauf erhoeht die Kosten fuer die naechste Farm`() {
-        gameService.initializeGame()
-        gameService.handleJoin("Alice")
-        gameService.handleJoin("Bob")
-        seedDualValleyCombatUnits()
-
-        val state = gameService.getCurrentState()
-        val alice = state.players.first { it.name == "Alice" }
-
-        alice.gold = 30
-
-        gameService.buyFarm(state, "Alice")
-        assertThat(alice.farms).isEqualTo(1)
-        assertThat(alice.gold).isEqualTo(20)
-
-        gameService.buyFarm(state, "Alice")
-        assertThat(alice.farms).isEqualTo(2)
-        assertThat(alice.gold).isEqualTo(9)
-    }
-
-    @Test
-    fun `test buyFarm - schlaegt bei zu wenig Gold fehl`() {
-        gameService.initializeGame()
-        gameService.handleJoin("Alice")
-        gameService.handleJoin("Bob")
-        seedDualValleyCombatUnits()
-
-        val state = gameService.getCurrentState()
-        val alice = state.players.first { it.name == "Alice" }
-
-        alice.gold = 9
-        gameService.buyFarm(state, "Alice")
-
-        assertThat(alice.farms).isEqualTo(0)
-        assertThat(alice.gold).isEqualTo(9)
-    }
-
-    @Test
     fun `test applyUpkeep - Farm-Einkommen verhindert Insolvenz`() {
         gameService.initializeGame()
         gameService.handleJoin("Alice")


### PR DESCRIPTION
**Problem / Zweck**

Das Wirtschaftssystem benötigt einen sauberen, raumspezifischen Endpunkt für den Kauf von Farmen. Der bisherige `/buyFarm`-Endpoint existierte noch als globales Mapping, was in der neuen Multi-Room-Architektur zu Fehlern führte. Dieses Issue portiert den Endpunkt auf die neue Struktur, integriert die Einkommensberechnung direkt beim Kauf und bereinigt alte Code-Leichen.

**Lösung**

Dieses PR setzt die Anforderungen für den raumspezifischen Kauf-Endpunkt vollständig um:

* **Endpoint & Netzwerk:** Der STOMP-Endpoint `@MessageMapping("/rooms/{roomId}/buy-farm")` wurde im `WebSocketBrokerController` implementiert. Er verarbeitet die Requests nun isoliert für den jeweiligen Raum und sendet den aktualisierten GameState als Broadcast.
* **Validierung:** Eine vollständige Validierungskette (`ROOM_NOT_FOUND`, `GAME_NOT_STARTED`, `NOT_YOUR_TURN`, `INSUFFICIENT_GOLD`) inklusive entsprechendem Error-Handling über die Queue wurde eingebaut.
* **Logik & Modell:** Das `income`-Attribut wurde zum `Player`-Modell hinzugefügt. Die dynamische Kostenberechnung (`FARM_BASE_COST + farms * FARM_COST_INCREMENT`) und das Update von Gold, Farm-Counter und Income passieren nun synchronisiert im Controller.
* **Clean Code:** Der veraltete globale Endpunkt sowie die alte `buyFarm`-Funktion im `GameService` wurden restlos als toter Code entfernt.
* Sämtliche Controller-Tests (Happy-Path inkl. Preiserhöhung, alle Error-Pfade und Edge-Cases) wurden neu geschrieben und sind grün. Veraltete Tests wurden gelöscht.

Closes #131