### PR TITLE
Feat/disconnected fields is skeleton

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Field.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Field.kt
@@ -10,9 +10,14 @@ package at.aau.hexabrawl.websocketserver.model
  *
  * `owner` ist mutable damit Felder durch Eroberung den Besitzer
  * wechseln koennen (siehe Folge-Sub-Issue #104).
+ *
+ * `isSkeleton` markiert Felder, die vom Hauptgebiet abgeschnitten
+ * wurden. Owner bleibt erhalten fuer Rueckeroberung. Default false;
+ * wird durch recomputeConnectivity gesetzt.
  */
 data class Field(
     val x: Int,
     val y: Int,
-    var owner: String? = null
+    var owner: String? = null,
+    var isSkeleton: Boolean = false
 )

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldTest.kt
@@ -102,4 +102,19 @@ class FieldTest {
             }
         }
     }
+
+    @Test
+    fun `new field has isSkeleton false by default`() {
+        val field = Field(x = 0, y = 0)
+        assertFalse(field.isSkeleton)
+    }
+
+    @Test
+    fun `isSkeleton can be toggled at runtime`() {
+        val field = Field(x = 0, y = 0)
+        field.isSkeleton = true
+        assertTrue(field.isSkeleton)
+        field.isSkeleton = false
+        assertFalse(field.isSkeleton)
+    }
 }


### PR DESCRIPTION


## Was

Erweitert die `Field`-Data-Class um eine neue `var isSkeleton: Boolean = false`. Bereitet Sub-Issue 2 (BFS-Connectivity-Check) und Sub-Issue 3 (Income-Filter) vor.

Keine Verhaltensänderung — Default `false` bedeutet, dass alle bestehenden Pfade weiterhin wie bisher arbeiten.

## Änderungen

- `Field.kt`: neue Property `isSkeleton: Boolean = false`, KDoc um Hinweis auf SKELETON-Semantik ergänzt
- `FieldTest.kt`: zwei Tests für Default-Wert und Mutability