### PR TITLE
Feat/disconnected fields connectivity check

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -404,6 +404,60 @@ class GameService(
         }
     }
 
+    /**
+     * Prueft fuer alle Spieler, ob ihre Felder noch ueber Hex-Nachbarn mit ihrer
+     * BASE verbunden sind. Felder ohne Pfad zur BASE werden zu SKELETON-Feldern,
+     * Einheiten darauf (ausser BASE/SKELETON) werden zu UnitType.SKELETON.
+     *
+     * Spieler ohne BASE-Unit werden uebersprungen — checkWinCondition kuemmert
+     * sich um deren Ausscheiden.
+     */
+    fun recomputeConnectivity(state: GameState) {
+        state.players.forEach { player ->
+            val baseUnit = state.units.firstOrNull {
+                it.player == player.name && it.type == UnitType.BASE
+            } ?: return@forEach
+
+            val connected = bfsConnectedFields(state, player.name, baseUnit.x, baseUnit.y)
+
+            state.fields.filter { it.owner == player.name && !it.isSkeleton }.forEach { field ->
+                if ((field.x to field.y) !in connected) {
+                    field.isSkeleton = true
+                    state.units.filter {
+                        it.x == field.x && it.y == field.y &&
+                            it.player == player.name &&
+                            it.type != UnitType.BASE &&
+                            it.type != UnitType.SKELETON
+                    }.forEach { it.type = UnitType.SKELETON }
+                }
+            }
+        }
+    }
+
+    private fun bfsConnectedFields(
+        state: GameState,
+        playerName: String,
+        startX: Int,
+        startY: Int
+    ): Set<Pair<Int, Int>> {
+        val visited = mutableSetOf(startX to startY)
+        val queue = ArrayDeque<Pair<Int, Int>>()
+        queue.add(startX to startY)
+
+        while (queue.isNotEmpty()) {
+            val (x, y) = queue.removeFirst()
+            for ((nx, ny) in hexNeighbors(x, y)) {
+                if ((nx to ny) in visited) continue
+                val field = state.fields.firstOrNull { it.x == nx && it.y == ny } ?: continue
+                if (field.owner != playerName) continue
+                if (field.isSkeleton) continue
+                visited.add(nx to ny)
+                queue.add(nx to ny)
+            }
+        }
+        return visited
+    }
+
     // WICHTIG FÜR TEST — nur den aktuellen Stand lesen
     fun getCurrentState(state: GameState): GameState = synchronized(state.lock) {
         return state

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -390,8 +390,12 @@ class GameService(
         if (unit in state.units) {
             unit.hasMovedThisTurn = true
             state.fields.firstOrNull { it.x == unit.x && it.y == unit.y }
-                ?.let { it.owner = playerName }
+                ?.let {
+                    it.owner = playerName
+                    it.isSkeleton = false
+                }
         }
+        recomputeConnectivity(state)
         if (allMovableUnitsHaveMoved(state, playerName)) {
             switchTurn(state)
         }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConnectivityTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConnectivityTest.kt
@@ -1,0 +1,93 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class FieldConnectivityTest {
+
+    private lateinit var gameService: GameService
+
+    @BeforeEach
+    fun setup() {
+        gameService = GameService(CombatService())
+    }
+
+    private fun stateWithBase(owner: String, baseX: Int, baseY: Int): GameState =
+        GameState().apply {
+            players.add(Player(name = owner))
+            units.add(GameUnit(player = owner, x = baseX, y = baseY, type = UnitType.BASE))
+            fields.add(Field(baseX, baseY, owner = owner))
+        }
+
+    @Test
+    fun `connected territory stays connected`() {
+        val state = stateWithBase("Alice", 0, 0).apply {
+            fields.add(Field(1, 0, owner = "Alice"))
+            fields.add(Field(2, 0, owner = "Alice"))
+        }
+        gameService.recomputeConnectivity(state)
+        assertTrue(state.fields.none { it.isSkeleton })
+    }
+
+    @Test
+    fun `isolated field becomes skeleton`() {
+        val state = stateWithBase("Alice", 0, 0).apply {
+            // (1,0) fehlt – (2,0) hat keinen Pfad zur BASE
+            fields.add(Field(2, 0, owner = "Alice"))
+        }
+        gameService.recomputeConnectivity(state)
+        val baseField = state.fields.first { it.x == 0 && it.y == 0 }
+        val isolated = state.fields.first { it.x == 2 && it.y == 0 }
+        assertFalse(baseField.isSkeleton)
+        assertTrue(isolated.isSkeleton)
+    }
+
+    @Test
+    fun `unit on isolated field becomes skeleton unit`() {
+        val state = stateWithBase("Alice", 0, 0).apply {
+            fields.add(Field(2, 0, owner = "Alice"))
+            units.add(GameUnit(player = "Alice", x = 2, y = 0, type = UnitType.INFANTRY))
+        }
+        gameService.recomputeConnectivity(state)
+        val infantry = state.units.first { it.x == 2 && it.y == 0 }
+        assertEquals(UnitType.SKELETON, infantry.type)
+    }
+
+    @Test
+    fun `narrow corridor keeps territory connected`() {
+        val state = stateWithBase("Alice", 0, 0).apply {
+            // Hex-Kette BASE (0,0) - (1,0) - (2,0) - (3,0) - (4,0)
+            fields.add(Field(1, 0, owner = "Alice"))
+            fields.add(Field(2, 0, owner = "Alice"))
+            fields.add(Field(3, 0, owner = "Alice"))
+            fields.add(Field(4, 0, owner = "Alice"))
+        }
+        gameService.recomputeConnectivity(state)
+        assertTrue(state.fields.none { it.isSkeleton })
+    }
+
+    @Test
+    fun `player without base is skipped without error`() {
+        val state = GameState().apply {
+            players.add(Player(name = "Alice"))
+            // Keine BASE-Unit – Spieler ist via checkWinCondition ohnehin raus
+            fields.add(Field(0, 0, owner = "Alice"))
+            fields.add(Field(1, 0, owner = "Alice"))
+        }
+        gameService.recomputeConnectivity(state)
+        assertTrue(state.fields.none { it.isSkeleton })
+    }
+
+    @Test
+    fun `skeleton corridor blocks bfs path`() {
+        val state = stateWithBase("Alice", 0, 0).apply {
+            // (1,0) ist Alice aber bereits SKELETON – sollte als Pfad nicht zählen
+            fields.add(Field(1, 0, owner = "Alice", isSkeleton = true))
+            fields.add(Field(2, 0, owner = "Alice"))
+        }
+        gameService.recomputeConnectivity(state)
+        val field20 = state.fields.first { it.x == 2 && it.y == 0 }
+        assertTrue(field20.isSkeleton)
+    }
+}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConnectivityTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConnectivityTest.kt
@@ -90,4 +90,65 @@ class FieldConnectivityTest {
         val field20 = state.fields.first { it.x == 2 && it.y == 0 }
         assertTrue(field20.isSkeleton)
     }
+
+    @Test
+    fun `own player recaptures own skeleton field via handleMove`() {
+        val state = GameState().apply {
+            status = GameStatus.IN_PROGRESS
+            currentTurn = "Alice"
+            players.add(Player(name = "Alice"))
+            units.add(GameUnit(player = "Alice", x = 0, y = 0, type = UnitType.BASE))
+            units.add(GameUnit(player = "Alice", x = 1, y = 0, type = UnitType.INFANTRY))
+            // Zweite Einheit, damit allMovableUnitsHaveMoved nicht gleich switchTurn triggert
+            units.add(GameUnit(player = "Alice", x = 0, y = 1, type = UnitType.CAVALRY))
+            fields.add(Field(0, 0, owner = "Alice"))
+            fields.add(Field(1, 0, owner = "Alice"))
+            fields.add(Field(2, 0, owner = "Alice", isSkeleton = true))
+        }
+
+        gameService.handleMove(state, Move(
+            player = "Alice",
+            type = UnitType.INFANTRY,
+            fromX = 1, fromY = 0,
+            toX = 2, toY = 0
+        ))
+
+        val recaptured = state.fields.first { it.x == 2 && it.y == 0 }
+        assertEquals("Alice", recaptured.owner)
+        assertFalse(recaptured.isSkeleton)
+        assertTrue(state.units.any {
+            it.player == "Alice" && it.type == UnitType.INFANTRY && it.x == 2 && it.y == 0
+        })
+    }
+
+    @Test
+    fun `opponent captures skeleton field via handleMove`() {
+        val state = GameState().apply {
+            status = GameStatus.IN_PROGRESS
+            currentTurn = "Bob"
+            players.add(Player(name = "Alice"))
+            players.add(Player(name = "Bob"))
+            units.add(GameUnit(player = "Alice", x = 0, y = 0, type = UnitType.BASE))
+            units.add(GameUnit(player = "Bob", x = 3, y = 0, type = UnitType.INFANTRY))
+            // Zweite Bob-Einheit, damit allMovableUnitsHaveMoved nicht gleich switchTurn triggert
+            units.add(GameUnit(player = "Bob", x = 4, y = 1, type = UnitType.CAVALRY))
+            fields.add(Field(0, 0, owner = "Alice"))
+            fields.add(Field(2, 0, owner = "Alice", isSkeleton = true))
+            fields.add(Field(3, 0, owner = "Bob"))
+        }
+
+        gameService.handleMove(state, Move(
+            player = "Bob",
+            type = UnitType.INFANTRY,
+            fromX = 3, fromY = 0,
+            toX = 2, toY = 0
+        ))
+
+        val captured = state.fields.first { it.x == 2 && it.y == 0 }
+        assertEquals("Bob", captured.owner)
+        assertFalse(captured.isSkeleton)
+        assertTrue(state.units.any {
+            it.player == "Bob" && it.type == UnitType.INFANTRY && it.x == 2 && it.y == 0
+        })
+    }
 }


### PR DESCRIPTION
## Was

Implementiert die BFS-Connectivity-Logik: Felder eines Spielers, die per Hex-Pfad nicht mehr mit seiner BASE verbunden sind, werden zu SKELETON-Feldern. Einheiten darauf werden zu `UnitType.SKELETON`. Rückeroberung passiert automatisch beim Drauf-Ziehen einer Einheit.

Trigger läuft nach jedem `handleMove` (in `finishMove`) — Combat-Pfad ist dadurch mitabgedeckt.

## Änderungen

- `GameService.kt`:
  - Neue public-Methode `recomputeConnectivity(state)`
  - Privater BFS-Helper `bfsConnectedFields`
  - `finishMove` ruft `recomputeConnectivity` und setzt `isSkeleton = false` bei Eroberung (Rückeroberung)
  - Wiederverwendet bestehenden `hexNeighbors`-Companion-Helper
- `FieldConnectivityTest.kt` (neu): 8 Tests — 6 direkte `recomputeConnectivity`-Cases + 2 `handleMove`-Integration für Rückeroberung
