### PR TITLE
Feat #152: Feld-Income zur Wirtschafts-Berechnung hinzufügen

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -20,6 +20,7 @@ class GameService(
         // Wirtschaftssystem (#60)
         const val STARTING_GOLD = 6
         const val FARM_INCOME_PER_ROUND = 3
+        const val FIELD_INCOME_PER_ROUND = 1
         const val FARM_BASE_COST = 10
         const val FARM_COST_INCREMENT = 1
 
@@ -498,9 +499,11 @@ class GameService(
      * Farm-Einkommen gutschreiben, Unterhalt abziehen (1. Einheit 3 Gold, jede weitere +1).
      * Bei Insolvenz: Gold auf 0, alle lebenden Truppen → SKELETON.
      */
-    private fun applyUpkeep(state: GameState) {
+    internal fun applyUpkeep(state: GameState) {
         state.players.forEach { player ->
-            player.gold += player.farms * FARM_INCOME_PER_ROUND
+            val ownedFields = state.fields.count { it.owner == player.name }
+            val income = ownedFields * FIELD_INCOME_PER_ROUND + player.farms * FARM_INCOME_PER_ROUND
+            player.gold += income
 
             val playerUnits = state.units.filter {
                 it.player == player.name && it.type != UnitType.SKELETON && it.type != UnitType.BASE
@@ -515,9 +518,9 @@ class GameService(
                 playerUnits.forEach { it.type = UnitType.SKELETON }
             }
         }
-
         checkWinCondition(state)
     }
+
 
     /**
      * Kauft eine neue Einheit und platziert sie an (x, y) (#132).

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -1,5 +1,6 @@
 package at.aau.hexabrawl.websocketserver.model
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -467,9 +468,10 @@ class GameServiceTest {
         gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, bobInf.x, bobInf.y + 1))
         gameService.endTurn("Bob")
 
-        // Bei 3 Start-Einheiten kostet der Unterhalt 12 Gold (3+4+5). 20 - 12 = 8.
-        assertThat(state.players.first { it.name == "Alice" }.gold).isEqualTo(8)
-        assertThat(state.players.first { it.name == "Bob" }.gold).isEqualTo(8)
+        // Alice erobert ein Feld (8 Felder) -> 20 + 8 - 12 = 16
+        assertThat(state.players.first { it.name == "Alice" }.gold).isEqualTo(16)
+        // Bob tritt vom Spielfeld (bleibt bei 7 Feldern) -> 20 + 7 - 12 = 15
+        assertThat(state.players.first { it.name == "Bob" }.gold).isEqualTo(15)
     }
 
     @Test
@@ -480,7 +482,8 @@ class GameServiceTest {
         seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
-        state.players.forEach { it.gold = 12 }
+        // 4 Startgold + 8 Feld-Gold = 12 Gold (genau der Unterhalt)
+        state.players.forEach { it.gold = 4 }
 
         val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
         gameService.handleMove(Move("Alice", UnitType.INFANTRY, aliceInf.x, aliceInf.y, aliceInf.x, aliceInf.y + 1))
@@ -503,7 +506,8 @@ class GameServiceTest {
         seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
-        state.players.first { it.name == "Alice" }.gold = 11
+        // 3 Startgold + 8 Feld-Gold = 11 Gold. Upkeep kostet 12 -> Insolvenz
+        state.players.first { it.name == "Alice" }.gold = 3
         state.players.first { it.name == "Bob" }.gold = 20
 
         val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
@@ -562,7 +566,7 @@ class GameServiceTest {
         val bob = state.players.first { it.name == "Bob" }
 
         alice.farms = 1
-        alice.gold = 10
+        alice.gold = 2
         bob.gold = 10
 
         val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
@@ -575,5 +579,47 @@ class GameServiceTest {
         assertThat(alice.gold).isEqualTo(1)
         assertThat(alice.farms).isEqualTo(1)
         assertThat(state.units.filter { it.player == "Alice" }.all { it.type != UnitType.SKELETON }).isTrue()
+    }
+
+    @Test
+    fun `field income added on top of farm income`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.add(Player(name = "Alice", gold = 0, farms = 1))
+            fields.addAll(listOf(
+                Field(0, 0, owner = "Alice"),
+                Field(0, 1, owner = "Alice"),
+                Field(0, 2, owner = "Alice")
+            ))
+        }
+        service.applyUpkeep(state)
+
+        // 3 Felder × 1 + 1 Farm × 3 = 6 Gold, keine Units → kein Upkeep
+        assertEquals(6, state.players[0].gold)
+    }
+
+    @Test
+    fun `field income works with zero farms`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.add(Player(name = "Alice", gold = 0, farms = 0))
+            fields.addAll(List(5) { Field(0, it, owner = "Alice") })
+        }
+        service.applyUpkeep(state)
+
+        assertEquals(5, state.players[0].gold)
+    }
+
+    @Test
+    fun `field income works with zero fields and zero farms`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.add(Player(name = "Alice", gold = 0, farms = 0))
+            // Keine Felder hinzufuegen
+        }
+
+        service.applyUpkeep(state)
+
+        assertEquals(0, state.players[0].gold)
     }
 }


### PR DESCRIPTION
**Problem / Zweck**

Das Wirtschaftssystem aus Issue #60 berechnete den Runden-Unterhalt und das Einkommen der Spieler bisher ausschließlich auf Basis der gebauten Farmen (`FARM_INCOME_PER_ROUND`). Laut der Spielregeln generiert jedoch auch jedes eigene Hex-Feld ein passives Einkommen von +1 Gold pro Runde. Dieser Anteil fehlte im Code komplett und musste ergänzt werden, ohne dabei den restlichen Upkeep-Pfad zu verändern.

**Lösung**

* **Logik & Konstanten:** Die Konstante `FIELD_INCOME_PER_ROUND = 1` wurde im `GameService` hinzugefügt.
* **Einkommens-Update:** Die Methode `applyUpkeep` wurde erweitert. Sie zählt nun die eigenen Felder des Spielers (`state.fields.count { it.owner == player.name }`) und addiert das resultierende Feld-Einkommen (`ownedFields * FIELD_INCOME_PER_ROUND`) zusätzlich zum Farm-Einkommen auf das Spielergold, bevor der Unterhalt der Truppen abgezogen wird.
* **Testing:** 
  * Drei neue isolierte Testfälle (`field income added on top of farm income`, `field income works with zero farms`, `field income works with zero fields and zero farms`) wurden geschrieben und decken alle Grenzfälle ab.
  * Bestehende Insolvenz- und Upkeep-Tests wurden an die neue Wirtschaftsrealität mathematisch korrekt angepasst (inklusive spezieller Grenzfälle am Spielfeldrand).
* Die Test-Suite ist zu 100 % grün.

Closes #152