### PR TITLE
Feat #153: Player-Modell um income und upkeep erweitern

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Player.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Player.kt
@@ -7,5 +7,6 @@ data class Player (
     val color: PlayerColor = PlayerColor.RED,
     var gold: Int = 0,
     var farms: Int = 0,
-    var income: Int = 0
+    var income: Int = 0,
+    var upkeep: Int = 0
 ){}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/PlayerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/PlayerTest.kt
@@ -1,0 +1,24 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.ObjectMapper
+
+class PlayerTest {
+    @Test
+    fun `player serializes and deserializes income and upkeep`() {
+        val mapper = ObjectMapper()
+        val original = Player(name = "Alice", income = 7, upkeep = 4)
+        val json = mapper.writeValueAsString(original)
+        val parsed = mapper.readValue(json, Player::class.java)
+        assertEquals(7, parsed.income)
+        assertEquals(4, parsed.upkeep)
+    }
+
+    @Test
+    fun `new player has income and upkeep zero by default`() {
+        val player = Player(name = "Alice")
+        assertEquals(0, player.income)
+        assertEquals(0, player.upkeep)
+    }
+}


### PR DESCRIPTION
**Problem / Zweck**

Das Frontend benötigt für die HUD-Anzeige (Einkommen-Detail-Popup) die vorberechneten Werte für das zukünftige Einkommen und den Unterhalt. Um eine Duplizierung der Berechnungslogik (z.B. die Summenformel für den Upkeep) im Client zu vermeiden, soll der Server diese Werte im Spielstatus mitliefern. Dieses Issue bereitet das Datenmodell dafür vor.

**Lösung**

* **Modell-Erweiterung:** Die `Player` Data-Class wurde um die Felder `income` und `upkeep` ergänzt (beide mit dem Default-Wert `0`). 
* **Semantik:** Diese Felder repräsentieren die prognostizierten Werte für den nächsten `endTurn`. Die eigentliche Berechnung erfolgt in Sub-Issue 3.
* **Testing:** Eine neue `PlayerTest`-Klasse wurde angelegt. Sie prüft die korrekte Initialisierung der Default-Werte und sichert die fehlerfreie JSON-Serialisierung/Deserialisierung via Jackson (Round-Trip) ab.
* Alle bestehenden Tests bleiben grün, da sich die Spielregeln durch dieses reine Daten-Setup nicht ändern.

Closes #153