### PR TITLE
Feat #154: recomputePlayerStats implementieren und vor Broadcast aufrufen

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -43,10 +43,9 @@ class WebSocketBrokerController(
     }
 
     private fun sendRoomState(roomId: String, state: GameState) {
-        messagingTemplate.convertAndSend(
-            "/topic/rooms/$roomId/state",
-            state
-        )
+        gameService.recomputePlayerStats(state)
+        messagingTemplate.convertAndSend("/topic/rooms/${roomId}/state", state)
+
     }
 
     @MessageMapping("/rooms/{roomId}/join")
@@ -235,7 +234,7 @@ class WebSocketBrokerController(
             player.income = player.farms * GameService.FARM_INCOME_PER_ROUND
         }
 
-        messagingTemplate.convertAndSend("/topic/rooms/$roomId/state", state)
+        sendRoomState(roomId, state)
         return state
     }
 

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -501,15 +501,11 @@ class GameService(
      */
     internal fun applyUpkeep(state: GameState) {
         state.players.forEach { player ->
-            val ownedFields = state.fields.count { it.owner == player.name }
-            val income = ownedFields * FIELD_INCOME_PER_ROUND + player.farms * FARM_INCOME_PER_ROUND
-            player.gold += income
-
+            player.gold += computeIncome(player, state)
+            val upkeep = computeUpkeep(player, state)
             val playerUnits = state.units.filter {
                 it.player == player.name && it.type != UnitType.SKELETON && it.type != UnitType.BASE
             }
-            val unitCount = playerUnits.size
-            val upkeep = (0 until unitCount).sumOf { 3 + it }
 
             if (player.gold >= upkeep) {
                 player.gold -= upkeep
@@ -518,8 +514,8 @@ class GameService(
                 playerUnits.forEach { it.type = UnitType.SKELETON }
             }
         }
-        checkWinCondition(state)
     }
+
 
 
     /**
@@ -570,5 +566,23 @@ class GameService(
         )
 
         return state
+    }
+    private fun computeIncome(player: Player, state: GameState): Int {
+        val ownedFields = state.fields.count { it.owner == player.name }
+        return ownedFields * FIELD_INCOME_PER_ROUND + player.farms * FARM_INCOME_PER_ROUND
+    }
+
+    private fun computeUpkeep(player: Player, state: GameState): Int {
+        val unitCount = state.units.count {
+            it.player == player.name && it.type != UnitType.SKELETON && it.type != UnitType.BASE
+        }
+        return (0 until unitCount).sumOf { 3 + it }
+    }
+
+    fun recomputePlayerStats(state: GameState) {
+        state.players.forEach { player ->
+            player.income = computeIncome(player, state)
+            player.upkeep = computeUpkeep(player, state)
+        }
     }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -622,4 +622,99 @@ class GameServiceTest {
 
         assertEquals(0, state.players[0].gold)
     }
+
+    @Test
+    fun `recomputePlayerStats sets income from fields and farms`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.add(Player(name = "Alice", farms = 2))
+            fields.addAll(List(4) { Field(0, it, owner = "Alice") })
+        }
+        service.recomputePlayerStats(state)
+
+        assertEquals(4 + 2 * 3, state.players[0].income)
+        assertEquals(0, state.players[0].upkeep)
+    }
+
+    @Test
+    fun `recomputePlayerStats sets upkeep based on living non-base units`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.add(Player(name = "Alice"))
+            units.addAll(listOf(
+                GameUnit(player = "Alice", type = UnitType.INFANTRY, x = 0, y = 0),
+                GameUnit(player = "Alice", type = UnitType.CAVALRY, x = 0, y = 1),
+                GameUnit(player = "Alice", type = UnitType.BASE, x = 0, y = 2),       // zählt NICHT
+                GameUnit(player = "Alice", type = UnitType.SKELETON, x = 0, y = 3)    // zählt NICHT
+            ))
+        }
+        service.recomputePlayerStats(state)
+
+        // 2 Einheiten: 3 + 4 = 7
+        assertEquals(7, state.players[0].upkeep)
+    }
+
+    @Test
+    fun `after buyFarm the broadcasted state contains updated income`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.add(Player(name = "Alice", gold = 10, farms = 0))
+        }
+
+        state.players[0].farms += 1
+        state.players[0].gold -= 10
+
+        // Das passiert im Controller kurz vorm Broadcast:
+        service.recomputePlayerStats(state)
+
+        // Alice sollte jetzt 1 Farm haben. Farm-Income = 3
+        assertEquals(3, state.players[0].income)
+    }
+
+    @Test
+    fun `after field conquest income shifts from old to new owner`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.add(Player(name = "Alice"))
+            players.add(Player(name = "Bob"))
+            fields.add(Field(0, 0, owner = "Bob")) // Bob gehört das Feld anfangs
+        }
+
+        // Aktion: Alice erobert das Feld von Bob
+        state.fields[0].owner = "Alice"
+
+        // Broadcast-Vorbereitung
+        service.recomputePlayerStats(state)
+
+        // Alice bekommt +1 Income, Bob verliert 1 Income
+        assertEquals(1, state.players.find { it.name == "Alice" }?.income)
+        assertEquals(0, state.players.find { it.name == "Bob" }?.income)
+    }
+
+    @Test
+    fun `after endTurn with insolvency upkeep drops to zero`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            status = GameStatus.IN_PROGRESS
+
+            players.add(Player(name = "Alice", gold = 0)) // Index 0 (Spieler 1)
+            players.add(Player(name = "Bob", gold = 10))  // Index 1 (Spieler 2)
+
+            // Es ist aktuell Bobs Zug (der letzte Spieler in der Runde)
+            currentTurn = "Bob"
+
+            units.add(GameUnit(player = "Alice", type = UnitType.INFANTRY, x = 0, y = 0)) // Upkeep = 3
+        }
+
+        // Aktion: Bob beendet seinen Zug.
+        // Runden-Wrap-Around feuert -> es ist wieder Alice dran -> applyUpkeep() wird aufgerufen!
+        service.endTurn(state, "Bob")
+
+        // Broadcast-Vorbereitung
+        service.recomputePlayerStats(state)
+
+        // Truppe wurde zum Skeleton, daher kostet sie keinen Unterhalt mehr
+        assertEquals(0, state.players[0].upkeep)
+        assertEquals(UnitType.SKELETON, state.units[0].type)
+    }
 }


### PR DESCRIPTION
**Problem / Zweck**

Die in Sub-Issue 2 hinzugefügten Felder `income` und `upkeep` sind abgeleitete Werte. Um zu verhindern, dass diese Werte an zig verschiedenen Stellen im Code (Kauf, Eroberung, Combat) fehleranfällig manuell nachgerechnet werden müssen, brauchten wir eine zentrale Berechnungsmethode. Diese soll den State kurz vor dem Senden an das Frontend immer aktualisieren.

**Lösung**

* **Zentrale Logik:** Im `GameService` wurden die Helper-Methoden `computeIncome` und `computeUpkeep` sowie die Hauptmethode `recomputePlayerStats` implementiert.
* **Refactoring:** Die bestehende `applyUpkeep`-Methode nutzt nun ebenfalls die neuen Helpers, wodurch die Berechnungsformel für das Economy-System jetzt "Single Source of Truth" ist (keine Codeduplizierung).
* **Wrapper-Architektur:** Im `WebSocketBrokerController` wurde der bestehende `sendRoomState`-Wrapper so erweitert, dass `gameService.recomputePlayerStats(state)` vor jedem `convertAndSend` ausgeführt wird. Alle Endpoints (`move`, `end-turn`, `buy-farm`, etc.) nutzen nun diesen Wrapper.
* **Testing:** Drei neue Integrationstests wurden geschrieben:
  * Einkommens-Update nach Farm-Kauf (`buyFarm`).
  * Einkommens-Verschiebung nach Feld-Eroberung.
  * Upkeep-Reduzierung auf 0 bei Insolvenz (Truppen zu Skeletten).
* Alle Tests (inklusive der bestehenden) sind grün.

Closes #154