### PR TITLE
Feat #151: Wirtschaftssystem Refactoring (Feld-Income & Per-Player Trigger)

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -43,10 +43,9 @@ class WebSocketBrokerController(
     }
 
     private fun sendRoomState(roomId: String, state: GameState) {
-        messagingTemplate.convertAndSend(
-            "/topic/rooms/$roomId/state",
-            state
-        )
+        gameService.recomputePlayerStats(state)
+        messagingTemplate.convertAndSend("/topic/rooms/${roomId}/state", state)
+
     }
 
     @MessageMapping("/rooms/{roomId}/join")
@@ -235,7 +234,7 @@ class WebSocketBrokerController(
             player.income = player.farms * GameService.FARM_INCOME_PER_ROUND
         }
 
-        messagingTemplate.convertAndSend("/topic/rooms/$roomId/state", state)
+        sendRoomState(roomId, state)
         return state
     }
 

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -20,6 +20,7 @@ class GameService(
         // Wirtschaftssystem (#60)
         const val STARTING_GOLD = 6
         const val FARM_INCOME_PER_ROUND = 3
+        const val FIELD_INCOME_PER_ROUND = 1
         const val FARM_BASE_COST = 10
         const val FARM_COST_INCREMENT = 1
 
@@ -498,9 +499,11 @@ class GameService(
      * Farm-Einkommen gutschreiben, Unterhalt abziehen (1. Einheit 3 Gold, jede weitere +1).
      * Bei Insolvenz: Gold auf 0, alle lebenden Truppen → SKELETON.
      */
-    private fun applyUpkeep(state: GameState) {
+    internal fun applyUpkeep(state: GameState) {
         state.players.forEach { player ->
-            player.gold += player.farms * FARM_INCOME_PER_ROUND
+            val ownedFields = state.fields.count { it.owner == player.name }
+            val income = ownedFields * FIELD_INCOME_PER_ROUND + player.farms * FARM_INCOME_PER_ROUND
+            player.gold += income
 
             val playerUnits = state.units.filter {
                 it.player == player.name && it.type != UnitType.SKELETON && it.type != UnitType.BASE
@@ -515,9 +518,9 @@ class GameService(
                 playerUnits.forEach { it.type = UnitType.SKELETON }
             }
         }
-
         checkWinCondition(state)
     }
+
 
     /**
      * Kauft eine neue Einheit und platziert sie an (x, y) (#132).

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -501,15 +501,11 @@ class GameService(
      */
     internal fun applyUpkeep(state: GameState) {
         state.players.forEach { player ->
-            val ownedFields = state.fields.count { it.owner == player.name }
-            val income = ownedFields * FIELD_INCOME_PER_ROUND + player.farms * FARM_INCOME_PER_ROUND
-            player.gold += income
-
+            player.gold += computeIncome(player, state)
+            val upkeep = computeUpkeep(player, state)
             val playerUnits = state.units.filter {
                 it.player == player.name && it.type != UnitType.SKELETON && it.type != UnitType.BASE
             }
-            val unitCount = playerUnits.size
-            val upkeep = (0 until unitCount).sumOf { 3 + it }
 
             if (player.gold >= upkeep) {
                 player.gold -= upkeep
@@ -518,8 +514,8 @@ class GameService(
                 playerUnits.forEach { it.type = UnitType.SKELETON }
             }
         }
-        checkWinCondition(state)
     }
+
 
 
     /**
@@ -570,5 +566,23 @@ class GameService(
         )
 
         return state
+    }
+    private fun computeIncome(player: Player, state: GameState): Int {
+        val ownedFields = state.fields.count { it.owner == player.name }
+        return ownedFields * FIELD_INCOME_PER_ROUND + player.farms * FARM_INCOME_PER_ROUND
+    }
+
+    private fun computeUpkeep(player: Player, state: GameState): Int {
+        val unitCount = state.units.count {
+            it.player == player.name && it.type != UnitType.SKELETON && it.type != UnitType.BASE
+        }
+        return (0 until unitCount).sumOf { 3 + it }
+    }
+
+    fun recomputePlayerStats(state: GameState) {
+        state.players.forEach { player ->
+            player.income = computeIncome(player, state)
+            player.upkeep = computeUpkeep(player, state)
+        }
     }
 }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -342,7 +342,10 @@ class GameService(
     private fun switchTurn(state: GameState) {
         if (state.players.isEmpty()) return
 
-        val wasFirstBefore = state.currentTurn == state.players[0].name
+        // Wirtschaft des Spielers, dessen Zug gerade endet
+        state.players.firstOrNull { it.name == state.currentTurn }?.let {
+            applyEconomy(state, it)
+        }
 
         if (state.players.size == 2) {
             val p1 = state.players[0]
@@ -357,13 +360,8 @@ class GameService(
             }
         }
 
-        // Neue Runde: alle Einheiten duerfen wieder ziehen.
+        // Neue Runde: alle Einheiten dürfen wieder ziehen
         state.units.forEach { it.hasMovedThisTurn = false }
-
-        // Runden-Wrap-Around: Upkeep wenn wieder Spieler 1 dran ist.
-        if (!wasFirstBefore && state.currentTurn == state.players[0].name) {
-            applyUpkeep(state)
-        }
     }
 
     private fun allMovableUnitsHaveMoved(state: GameState, playerName: String): Boolean {
@@ -499,24 +497,20 @@ class GameService(
      * Farm-Einkommen gutschreiben, Unterhalt abziehen (1. Einheit 3 Gold, jede weitere +1).
      * Bei Insolvenz: Gold auf 0, alle lebenden Truppen → SKELETON.
      */
-    internal fun applyUpkeep(state: GameState) {
-        state.players.forEach { player ->
-            player.gold += computeIncome(player, state)
-            val upkeep = computeUpkeep(player, state)
-            val playerUnits = state.units.filter {
-                it.player == player.name && it.type != UnitType.SKELETON && it.type != UnitType.BASE
-            }
+    private fun applyEconomy(state: GameState, player: Player) {
+        player.gold += computeIncome(player, state)
+        val upkeep = computeUpkeep(player, state)
+        val playerUnits = state.units.filter {
+            it.player == player.name && it.type != UnitType.SKELETON && it.type != UnitType.BASE
+        }
 
-            if (player.gold >= upkeep) {
-                player.gold -= upkeep
-            } else {
-                player.gold = 0
-                playerUnits.forEach { it.type = UnitType.SKELETON }
-            }
+        if (player.gold >= upkeep) {
+            player.gold -= upkeep
+        } else {
+            player.gold = 0
+            playerUnits.forEach { it.type = UnitType.SKELETON }
         }
     }
-
-
 
     /**
      * Kauft eine neue Einheit und platziert sie an (x, y) (#132).

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Player.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Player.kt
@@ -7,5 +7,6 @@ data class Player (
     val color: PlayerColor = PlayerColor.RED,
     var gold: Int = 0,
     var farms: Int = 0,
-    var income: Int = 0
+    var income: Int = 0,
+    var upkeep: Int = 0
 ){}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/PlayerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/PlayerTest.kt
@@ -1,0 +1,24 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.ObjectMapper
+
+class PlayerTest {
+    @Test
+    fun `player serializes and deserializes income and upkeep`() {
+        val mapper = ObjectMapper()
+        val original = Player(name = "Alice", income = 7, upkeep = 4)
+        val json = mapper.writeValueAsString(original)
+        val parsed = mapper.readValue(json, Player::class.java)
+        assertEquals(7, parsed.income)
+        assertEquals(4, parsed.upkeep)
+    }
+
+    @Test
+    fun `new player has income and upkeep zero by default`() {
+        val player = Player(name = "Alice")
+        assertEquals(0, player.income)
+        assertEquals(0, player.upkeep)
+    }
+}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -754,9 +754,10 @@ class GameServiceTest {
     }
 
     @Test
-    fun `each player gets exactly one income per full round`() {
+    fun `each player gets exactly one income per full round in TRIAD_OUTPOST`() {
         val service = GameService(CombatService())
         val state = GameState().apply {
+            gameMode = GameMode.TRIAD_OUTPOST
             players.addAll(listOf(
                 Player(name = "Alice", gold = 0, farms = 1),
                 Player(name = "Bob",   gold = 0, farms = 1),
@@ -795,5 +796,59 @@ class GameServiceTest {
         assertEquals(UnitType.SKELETON, state.units[0].type)   // Alice insolvent
         assertEquals(100, state.players[1].gold)
         assertEquals(UnitType.INFANTRY, state.units[1].type)   // Bob unangetastet
+    }
+
+    @Test
+    fun `each player gets exactly one income per full round in BATTLEFIELD_PEAKS`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            gameMode = GameMode.BATTLEFIELD_PEAKS
+            players.addAll(listOf(
+                Player(name = "Alice", gold = 0, farms = 1),
+                Player(name = "Bob",   gold = 0, farms = 1),
+                Player(name = "Carol", gold = 0, farms = 1),
+                Player(name = "Dave",  gold = 0, farms = 1)
+            ))
+            currentTurn = "Alice"
+            status = GameStatus.IN_PROGRESS
+        }
+        service.endTurn(state, "Alice")
+        service.endTurn(state, "Bob")
+        service.endTurn(state, "Carol")
+        service.endTurn(state, "Dave")
+
+        assertEquals(3, state.players[0].gold)
+        assertEquals(3, state.players[1].gold)
+        assertEquals(3, state.players[2].gold)
+        assertEquals(3, state.players[3].gold)
+    }
+
+    @Test
+    fun `disconnect ends game cleanly without triggering further economy ticks`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            gameMode = GameMode.TRIAD_OUTPOST
+            players.addAll(listOf(
+                Player(name = "Alice", sessionId = "sess-alice", gold = 0, farms = 1),
+                Player(name = "Bob",   sessionId = "sess-bob",   gold = 0, farms = 1),
+                Player(name = "Carol", sessionId = "sess-carol", gold = 0, farms = 1)
+            ))
+            units.addAll(listOf(
+                GameUnit(player = "Alice", type = UnitType.BASE, x = 0, y = 0),
+                GameUnit(player = "Bob",   type = UnitType.BASE, x = 5, y = 5),
+                GameUnit(player = "Carol", type = UnitType.BASE, x = 10, y = 10)
+            ))
+            currentTurn = "Bob"
+            status = GameStatus.IN_PROGRESS
+        }
+
+        service.handleDisconnect(state, "sess-alice")
+
+        // Spiel ist beendet (TRIAD-Fallback bei Disconnect)
+        assertEquals(GameStatus.FINISHED, state.status)
+
+        // Verbleibende Spieler haben keinen ungewollten Income-Tick bekommen
+        assertEquals(0, state.players.first { it.name == "Bob" }.gold)
+        assertEquals(0, state.players.first { it.name == "Carol" }.gold)
     }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -449,7 +449,7 @@ class GameServiceTest {
     }
 
     @Test
-    fun `test applyUpkeep - normaler Abzug`() {
+    fun `test applyEconomy - normaler Abzug`() {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
@@ -461,21 +461,24 @@ class GameServiceTest {
         // Alice bewegt eine Einheit zu einem gueltigen Randfeld und beendet Runde
         val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
         gameService.handleMove(Move("Alice", UnitType.INFANTRY, aliceInf.x, aliceInf.y, aliceInf.x, aliceInf.y + 1))
+
+        // Aktion: Alice beendet den Zug -> applyEconomy triggert SOFORT für Alice
         gameService.endTurn("Alice")
 
-        // Bob bewegt eine Einheit und beendet Runde -> Runden-Wrap-Around -> applyUpkeep
+        // Check direkt nach Alice' Zug: Alice erobert ein Feld (8 Felder) -> 20 + 8 - 12 = 16
+        assertThat(state.players.first { it.name == "Alice" }.gold).isEqualTo(16)
+
+        // Bob bewegt eine Einheit und beendet Runde -> applyEconomy triggert für Bob
         val bobInf = state.units.first { it.player == "Bob" && it.type == UnitType.INFANTRY }
         gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, bobInf.x, bobInf.y + 1))
         gameService.endTurn("Bob")
 
-        // Alice erobert ein Feld (8 Felder) -> 20 + 8 - 12 = 16
-        assertThat(state.players.first { it.name == "Alice" }.gold).isEqualTo(16)
-        // Bob tritt vom Spielfeld (bleibt bei 7 Feldern) -> 20 + 7 - 12 = 15
+        // Check nach Bobs Zug: Bob tritt vom Spielfeld (bleibt bei 7 Feldern) -> 20 + 7 - 12 = 15
         assertThat(state.players.first { it.name == "Bob" }.gold).isEqualTo(15)
     }
 
     @Test
-    fun `test applyUpkeep - Grenzfall exakt 0`() {
+    fun `test applyEconomy - Grenzfall exakt 0`() {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
@@ -487,19 +490,18 @@ class GameServiceTest {
 
         val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
         gameService.handleMove(Move("Alice", UnitType.INFANTRY, aliceInf.x, aliceInf.y, aliceInf.x, aliceInf.y + 1))
+
+        // Alice beendet den Zug
         gameService.endTurn("Alice")
 
-        val bobInf = state.units.first { it.player == "Bob" && it.type == UnitType.INFANTRY }
-        gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, bobInf.x, bobInf.y + 1))
-        gameService.endTurn("Bob")
-
+        // Prüfen: Alice ist bei exakt 0, behält aber ihre Einheiten
         val alice = state.players.first { it.name == "Alice" }
         assertThat(alice.gold).isEqualTo(0)
         assertThat(state.units.count { it.player == "Alice" }).isEqualTo(4)
     }
 
     @Test
-    fun `test applyUpkeep - Insolvenz mit Unit-Verlust`() {
+    fun `test applyEconomy - Insolvenz mit Unit-Verlust`() {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
@@ -512,11 +514,9 @@ class GameServiceTest {
 
         val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
         gameService.handleMove(Move("Alice", UnitType.INFANTRY, aliceInf.x, aliceInf.y, aliceInf.x, aliceInf.y + 1))
-        gameService.endTurn("Alice")
 
-        val bobInf = state.units.first { it.player == "Bob" && it.type == UnitType.INFANTRY }
-        gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, bobInf.x, bobInf.y + 1))
-        gameService.endTurn("Bob")
+        // Alice beendet den Zug und geht SOFORT insolvent
+        gameService.endTurn("Alice")
 
         val alice = state.players.first { it.name == "Alice" }
 
@@ -526,13 +526,13 @@ class GameServiceTest {
         // Die Einheiten sind noch da (3 Truppen und die Basis)
         val aliceUnits = state.units.filter { it.player == "Alice" }
         assertThat(aliceUnits.size).isEqualTo(4)
-        // Aber alle Truppen sind zu Skeletten geworden
+        // Aber alle Truppen sind sofort zu Skeletten geworden
         val aliceArmy = aliceUnits.filter { it.type != UnitType.BASE }
         assertThat(aliceArmy.all { it.type == UnitType.SKELETON }).isTrue()
     }
 
     @Test
-    fun `test applyUpkeep - Insolvenz loest keine Win-Condition aus`() {
+    fun `test applyEconomy - Insolvenz loest keine Win-Condition aus`() {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
@@ -544,11 +544,9 @@ class GameServiceTest {
 
         val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
         gameService.handleMove(Move("Alice", UnitType.INFANTRY, aliceInf.x, aliceInf.y, aliceInf.x, aliceInf.y + 1))
-        gameService.endTurn("Alice")
 
-        val bobInf = state.units.first { it.player == "Bob" && it.type == UnitType.INFANTRY }
-        gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, bobInf.x, bobInf.y + 1))
-        gameService.endTurn("Bob")
+        // Alice beendet Zug -> wird insolvent
+        gameService.endTurn("Alice")
 
         // Da Alice durch Insolvenz zwar ihre Armee verliert, aber die Basis noch steht, geht das Spiel weiter.
         assertThat(state.status).isEqualTo(GameStatus.IN_PROGRESS)
@@ -556,11 +554,12 @@ class GameServiceTest {
     }
 
     @Test
-    fun `test applyUpkeep - Farm-Einkommen verhindert Insolvenz`() {
+    fun `test applyEconomy - Farm-Einkommen verhindert Insolvenz`() {
         gameService.initializeGame()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
         seedDualValleyCombatUnits()
+
         val state = gameService.getCurrentState()
         val alice = state.players.first { it.name == "Alice" }
         val bob = state.players.first { it.name == "Bob" }
@@ -571,11 +570,11 @@ class GameServiceTest {
 
         val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
         gameService.handleMove(Move("Alice", UnitType.INFANTRY, aliceInf.x, aliceInf.y, aliceInf.x, aliceInf.y + 1))
-        gameService.endTurn("Alice")
-        val bobInf = state.units.first { it.player == "Bob" && it.type == UnitType.INFANTRY }
-        gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, bobInf.x, bobInf.y + 1))
-        gameService.endTurn("Bob")
 
+        // Alice beendet den Zug
+        gameService.endTurn("Alice")
+
+        // Prüfen: 2 Startgold + 8 Feld-Gold + 3 Farm-Gold = 13 Gold. - 12 Upkeep = 1 Gold.
         assertThat(alice.gold).isEqualTo(1)
         assertThat(alice.farms).isEqualTo(1)
         assertThat(state.units.filter { it.player == "Alice" }.all { it.type != UnitType.SKELETON }).isTrue()
@@ -585,6 +584,10 @@ class GameServiceTest {
     fun `field income added on top of farm income`() {
         val service = GameService(CombatService())
         val state = GameState().apply {
+            // Spiel starten und Alice an die Reihe setzen
+            status = GameStatus.IN_PROGRESS
+            currentTurn = "Alice"
+
             players.add(Player(name = "Alice", gold = 0, farms = 1))
             fields.addAll(listOf(
                 Field(0, 0, owner = "Alice"),
@@ -592,7 +595,10 @@ class GameServiceTest {
                 Field(0, 2, owner = "Alice")
             ))
         }
-        service.applyUpkeep(state)
+
+        // Statt applyUpkeep beendet Alice jetzt offiziell ihren Zug.
+        // Weil sie laut currentTurn dran war, wird ihre Wirtschaft jetzt berechnet
+        service.endTurn(state, "Alice")
 
         // 3 Felder × 1 + 1 Farm × 3 = 6 Gold, keine Units → kein Upkeep
         assertEquals(6, state.players[0].gold)
@@ -602,10 +608,16 @@ class GameServiceTest {
     fun `field income works with zero farms`() {
         val service = GameService(CombatService())
         val state = GameState().apply {
+            // Spiel starten und Alice an die Reihe setzen
+            status = GameStatus.IN_PROGRESS
+            currentTurn = "Alice"
+
             players.add(Player(name = "Alice", gold = 0, farms = 0))
             fields.addAll(List(5) { Field(0, it, owner = "Alice") })
         }
-        service.applyUpkeep(state)
+
+        // Zug beenden
+        service.endTurn(state, "Alice")
 
         assertEquals(5, state.players[0].gold)
     }
@@ -614,11 +626,14 @@ class GameServiceTest {
     fun `field income works with zero fields and zero farms`() {
         val service = GameService(CombatService())
         val state = GameState().apply {
+            status = GameStatus.IN_PROGRESS
+            currentTurn = "Alice"
+
             players.add(Player(name = "Alice", gold = 0, farms = 0))
             // Keine Felder hinzufuegen
         }
 
-        service.applyUpkeep(state)
+        service.endTurn(state, "Alice")
 
         assertEquals(0, state.players[0].gold)
     }
@@ -697,24 +712,88 @@ class GameServiceTest {
         val state = GameState().apply {
             status = GameStatus.IN_PROGRESS
 
-            players.add(Player(name = "Alice", gold = 0)) // Index 0 (Spieler 1)
-            players.add(Player(name = "Bob", gold = 10))  // Index 1 (Spieler 2)
+            players.add(Player(name = "Alice", gold = 0)) // Index 0
+            players.add(Player(name = "Bob", gold = 10))  // Index 1
 
-            // Es ist aktuell Bobs Zug (der letzte Spieler in der Runde)
-            currentTurn = "Bob"
+            // Alice ist am Zug
+            currentTurn = "Alice"
 
             units.add(GameUnit(player = "Alice", type = UnitType.INFANTRY, x = 0, y = 0)) // Upkeep = 3
         }
 
-        // Aktion: Bob beendet seinen Zug.
-        // Runden-Wrap-Around feuert -> es ist wieder Alice dran -> applyUpkeep() wird aufgerufen!
-        service.endTurn(state, "Bob")
+        // Aktion: Alice beendet ihren Zug. applyEconomy() wird für sie aufgerufen.
+        service.endTurn(state, "Alice")
 
-        // Broadcast-Vorbereitung
+        // Broadcast-Vorbereitung (simuliert den Controller)
         service.recomputePlayerStats(state)
 
-        // Truppe wurde zum Skeleton, daher kostet sie keinen Unterhalt mehr
+        // Alices Truppe wurde zum Skeleton, daher kostet sie keinen Unterhalt mehr
         assertEquals(0, state.players[0].upkeep)
         assertEquals(UnitType.SKELETON, state.units[0].type)
+
+        // Beweis, dass der Turn sauber an Bob weitergegeben wurde
+        assertEquals("Bob", state.currentTurn)
+    }
+
+    @Test
+    fun `endTurn applies economy only to the ending player`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.addAll(listOf(
+                Player(name = "Alice", gold = 0, farms = 1),
+                Player(name = "Bob", gold = 0, farms = 1)
+            ))
+            currentTurn = "Alice"
+            status = GameStatus.IN_PROGRESS
+        }
+        service.endTurn(state, "Alice")
+
+        assertEquals(3, state.players[0].gold)  // Alice: 1 Farm × 3
+        assertEquals(0, state.players[1].gold)  // Bob unverändert
+        assertEquals("Bob", state.currentTurn)
+    }
+
+    @Test
+    fun `each player gets exactly one income per full round`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.addAll(listOf(
+                Player(name = "Alice", gold = 0, farms = 1),
+                Player(name = "Bob",   gold = 0, farms = 1),
+                Player(name = "Carol", gold = 0, farms = 1)
+            ))
+            currentTurn = "Alice"
+            status = GameStatus.IN_PROGRESS
+        }
+        service.endTurn(state, "Alice")
+        service.endTurn(state, "Bob")
+        service.endTurn(state, "Carol")
+
+        assertEquals(3, state.players[0].gold)
+        assertEquals(3, state.players[1].gold)
+        assertEquals(3, state.players[2].gold)
+    }
+
+    @Test
+    fun `insolvency only affects the ending player`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.addAll(listOf(
+                Player(name = "Alice", gold = 0, farms = 0),
+                Player(name = "Bob",   gold = 100, farms = 0)
+            ))
+            units.addAll(listOf(
+                GameUnit(player = "Alice", type = UnitType.INFANTRY, x = 0, y = 0),
+                GameUnit(player = "Bob",   type = UnitType.INFANTRY, x = 1, y = 1)
+            ))
+            currentTurn = "Alice"
+            status = GameStatus.IN_PROGRESS
+        }
+        service.endTurn(state, "Alice")
+
+        assertEquals(0, state.players[0].gold)
+        assertEquals(UnitType.SKELETON, state.units[0].type)   // Alice insolvent
+        assertEquals(100, state.players[1].gold)
+        assertEquals(UnitType.INFANTRY, state.units[1].type)   // Bob unangetastet
     }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -622,4 +622,99 @@ class GameServiceTest {
 
         assertEquals(0, state.players[0].gold)
     }
+
+    @Test
+    fun `recomputePlayerStats sets income from fields and farms`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.add(Player(name = "Alice", farms = 2))
+            fields.addAll(List(4) { Field(0, it, owner = "Alice") })
+        }
+        service.recomputePlayerStats(state)
+
+        assertEquals(4 + 2 * 3, state.players[0].income)
+        assertEquals(0, state.players[0].upkeep)
+    }
+
+    @Test
+    fun `recomputePlayerStats sets upkeep based on living non-base units`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.add(Player(name = "Alice"))
+            units.addAll(listOf(
+                GameUnit(player = "Alice", type = UnitType.INFANTRY, x = 0, y = 0),
+                GameUnit(player = "Alice", type = UnitType.CAVALRY, x = 0, y = 1),
+                GameUnit(player = "Alice", type = UnitType.BASE, x = 0, y = 2),       // zählt NICHT
+                GameUnit(player = "Alice", type = UnitType.SKELETON, x = 0, y = 3)    // zählt NICHT
+            ))
+        }
+        service.recomputePlayerStats(state)
+
+        // 2 Einheiten: 3 + 4 = 7
+        assertEquals(7, state.players[0].upkeep)
+    }
+
+    @Test
+    fun `after buyFarm the broadcasted state contains updated income`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.add(Player(name = "Alice", gold = 10, farms = 0))
+        }
+
+        state.players[0].farms += 1
+        state.players[0].gold -= 10
+
+        // Das passiert im Controller kurz vorm Broadcast:
+        service.recomputePlayerStats(state)
+
+        // Alice sollte jetzt 1 Farm haben. Farm-Income = 3
+        assertEquals(3, state.players[0].income)
+    }
+
+    @Test
+    fun `after field conquest income shifts from old to new owner`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.add(Player(name = "Alice"))
+            players.add(Player(name = "Bob"))
+            fields.add(Field(0, 0, owner = "Bob")) // Bob gehört das Feld anfangs
+        }
+
+        // Aktion: Alice erobert das Feld von Bob
+        state.fields[0].owner = "Alice"
+
+        // Broadcast-Vorbereitung
+        service.recomputePlayerStats(state)
+
+        // Alice bekommt +1 Income, Bob verliert 1 Income
+        assertEquals(1, state.players.find { it.name == "Alice" }?.income)
+        assertEquals(0, state.players.find { it.name == "Bob" }?.income)
+    }
+
+    @Test
+    fun `after endTurn with insolvency upkeep drops to zero`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            status = GameStatus.IN_PROGRESS
+
+            players.add(Player(name = "Alice", gold = 0)) // Index 0 (Spieler 1)
+            players.add(Player(name = "Bob", gold = 10))  // Index 1 (Spieler 2)
+
+            // Es ist aktuell Bobs Zug (der letzte Spieler in der Runde)
+            currentTurn = "Bob"
+
+            units.add(GameUnit(player = "Alice", type = UnitType.INFANTRY, x = 0, y = 0)) // Upkeep = 3
+        }
+
+        // Aktion: Bob beendet seinen Zug.
+        // Runden-Wrap-Around feuert -> es ist wieder Alice dran -> applyUpkeep() wird aufgerufen!
+        service.endTurn(state, "Bob")
+
+        // Broadcast-Vorbereitung
+        service.recomputePlayerStats(state)
+
+        // Truppe wurde zum Skeleton, daher kostet sie keinen Unterhalt mehr
+        assertEquals(0, state.players[0].upkeep)
+        assertEquals(UnitType.SKELETON, state.units[0].type)
+    }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -1,5 +1,6 @@
 package at.aau.hexabrawl.websocketserver.model
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -467,9 +468,10 @@ class GameServiceTest {
         gameService.handleMove(Move("Bob", UnitType.INFANTRY, bobInf.x, bobInf.y, bobInf.x, bobInf.y + 1))
         gameService.endTurn("Bob")
 
-        // Bei 3 Start-Einheiten kostet der Unterhalt 12 Gold (3+4+5). 20 - 12 = 8.
-        assertThat(state.players.first { it.name == "Alice" }.gold).isEqualTo(8)
-        assertThat(state.players.first { it.name == "Bob" }.gold).isEqualTo(8)
+        // Alice erobert ein Feld (8 Felder) -> 20 + 8 - 12 = 16
+        assertThat(state.players.first { it.name == "Alice" }.gold).isEqualTo(16)
+        // Bob tritt vom Spielfeld (bleibt bei 7 Feldern) -> 20 + 7 - 12 = 15
+        assertThat(state.players.first { it.name == "Bob" }.gold).isEqualTo(15)
     }
 
     @Test
@@ -480,7 +482,8 @@ class GameServiceTest {
         seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
-        state.players.forEach { it.gold = 12 }
+        // 4 Startgold + 8 Feld-Gold = 12 Gold (genau der Unterhalt)
+        state.players.forEach { it.gold = 4 }
 
         val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
         gameService.handleMove(Move("Alice", UnitType.INFANTRY, aliceInf.x, aliceInf.y, aliceInf.x, aliceInf.y + 1))
@@ -503,7 +506,8 @@ class GameServiceTest {
         seedDualValleyCombatUnits()
 
         val state = gameService.getCurrentState()
-        state.players.first { it.name == "Alice" }.gold = 11
+        // 3 Startgold + 8 Feld-Gold = 11 Gold. Upkeep kostet 12 -> Insolvenz
+        state.players.first { it.name == "Alice" }.gold = 3
         state.players.first { it.name == "Bob" }.gold = 20
 
         val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
@@ -562,7 +566,7 @@ class GameServiceTest {
         val bob = state.players.first { it.name == "Bob" }
 
         alice.farms = 1
-        alice.gold = 10
+        alice.gold = 2
         bob.gold = 10
 
         val aliceInf = state.units.first { it.player == "Alice" && it.type == UnitType.INFANTRY }
@@ -575,5 +579,47 @@ class GameServiceTest {
         assertThat(alice.gold).isEqualTo(1)
         assertThat(alice.farms).isEqualTo(1)
         assertThat(state.units.filter { it.player == "Alice" }.all { it.type != UnitType.SKELETON }).isTrue()
+    }
+
+    @Test
+    fun `field income added on top of farm income`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.add(Player(name = "Alice", gold = 0, farms = 1))
+            fields.addAll(listOf(
+                Field(0, 0, owner = "Alice"),
+                Field(0, 1, owner = "Alice"),
+                Field(0, 2, owner = "Alice")
+            ))
+        }
+        service.applyUpkeep(state)
+
+        // 3 Felder × 1 + 1 Farm × 3 = 6 Gold, keine Units → kein Upkeep
+        assertEquals(6, state.players[0].gold)
+    }
+
+    @Test
+    fun `field income works with zero farms`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.add(Player(name = "Alice", gold = 0, farms = 0))
+            fields.addAll(List(5) { Field(0, it, owner = "Alice") })
+        }
+        service.applyUpkeep(state)
+
+        assertEquals(5, state.players[0].gold)
+    }
+
+    @Test
+    fun `field income works with zero fields and zero farms`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.add(Player(name = "Alice", gold = 0, farms = 0))
+            // Keine Felder hinzufuegen
+        }
+
+        service.applyUpkeep(state)
+
+        assertEquals(0, state.players[0].gold)
     }
 }


### PR DESCRIPTION
**Problem / Kontext**
Das bisherige Wirtschaftssystem aus #60 wich in zwei wesentlichen Punkten von der Spielregel ab:
1. Das Feld-Einkommen fehlte komplett (es wurden nur Farmen berechnet).
2. Der Trigger-Zeitpunkt war falsch und fehleranfällig: Das Geld wurde für alle Spieler gleichzeitig am Ende einer Voll-Runde berechnet (Round-Wrap-Around), was zu asymmetrischer UX führte und bei Disconnects oder 3-4 Spieler-Modi brechen konnte.

**Lösung / Umsetzung**
Dieses PR fasst die Refactoring-Schritte aller Sub-Issues zusammen und behebt die Probleme vollständig:

* **Feld-Einkommen integriert:** Das Einkommen berechnet sich nun korrekt aus `(Farmen × 3) + (Besetzte Felder × 1)`. Die Logik dafür wurde sauber in `computeIncome` und `computeUpkeep` zentralisiert.
* **Neues Timing (Per-Player Trigger):** `applyUpkeep` wurde durch `applyEconomy` ersetzt. Jeder Spieler erhält sein Income und zahlt seinen Upkeep (inkl. sofortiger Insolvenz-Prüfung) nun exakt in dem Moment, in dem er seinen eigenen Zug beendet.
* **Cleanup der Turn-Logik:** Die fehleranfällige Runden-Wrap-Around-Logik und veraltete Status-Variablen wurden komplett aus `switchTurn` entfernt. Das System ist nun robust gegen Disconnects und unabhängig von der Spieler-Reihenfolge.
* **Frontend-Vorbereitung:** Die neuen Stats (`gold`, `upkeep`, `income`, `farms`) werden bei Aktionen nun über den Controller via `recomputePlayerStats` direkt an die Clients gefunkt.
* **Testing:** Sämtliche bestehenden Economy-Tests wurden an das neue Per-Player-Timing angepasst. Es wurden diverse neue Integrationstests hinzugefügt (Prüfung von exaktem Feld-Einkommen, per-Player Insolvenz, Isolierung der Spieler-Wirtschaft). Alle Tests laufen fehlerfrei durch.

Closes #151