### PR TITLE
Feat/disconnected fields income filter

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -620,7 +620,7 @@ class GameService(
         return state
     }
     private fun computeIncome(player: Player, state: GameState): Int {
-        val ownedFields = state.fields.count { it.owner == player.name }
+        val ownedFields = state.fields.count { it.owner == player.name && !it.isSkeleton }
         return ownedFields * FIELD_INCOME_PER_ROUND + player.farms * FARM_INCOME_PER_ROUND
     }
 

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -639,6 +639,65 @@ class GameServiceTest {
     }
 
     @Test
+    fun `field income excludes skeleton fields`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            status = GameStatus.IN_PROGRESS
+            currentTurn = "Alice"
+
+            players.add(Player(name = "Alice", gold = 0, farms = 0))
+            // 3 Felder, davon 1 SKELETON
+            fields.add(Field(0, 0, owner = "Alice"))
+            fields.add(Field(0, 1, owner = "Alice"))
+            fields.add(Field(0, 2, owner = "Alice", isSkeleton = true))
+        }
+
+        service.endTurn(state, "Alice")
+
+        // Nur 2 von 3 Feldern zaehlen
+        assertEquals(2, state.players[0].gold)
+    }
+
+    @Test
+    fun `field income is zero when all fields are skeleton`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            status = GameStatus.IN_PROGRESS
+            currentTurn = "Alice"
+
+            players.add(Player(name = "Alice", gold = 0, farms = 1))
+            fields.addAll(List(3) { Field(0, it, owner = "Alice", isSkeleton = true) })
+        }
+
+        service.endTurn(state, "Alice")
+
+        // Nur Farm-Income (1 × 3 = 3), kein Feld-Income
+        assertEquals(3, state.players[0].gold)
+    }
+
+    @Test
+    fun `recomputePlayerStats income drops when a field becomes skeleton`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.add(Player(name = "Alice", farms = 0))
+            fields.add(Field(0, 0, owner = "Alice"))
+            fields.add(Field(0, 1, owner = "Alice"))
+            fields.add(Field(0, 2, owner = "Alice"))
+        }
+
+        service.recomputePlayerStats(state)
+        val incomeBefore = state.players[0].income
+
+        // Eines der Felder wird abgeschnitten
+        state.fields[1].isSkeleton = true
+        service.recomputePlayerStats(state)
+        val incomeAfter = state.players[0].income
+
+        assertEquals(3, incomeBefore)
+        assertEquals(2, incomeAfter)
+    }
+
+    @Test
     fun `recomputePlayerStats sets income from fields and farms`() {
         val service = GameService(CombatService())
         val state = GameState().apply {


### PR DESCRIPTION
## Was

Schließt SKELETON-Felder aus der Income-Berechnung aus. Felder mit `isSkeleton = true` zählen nicht mehr als ertragbringende Felder, obwohl der `owner` erhalten bleibt (für Rückeroberung).

Single-Line-Filter in `computeIncome`. Wirkt automatisch auf alle Code-Pfade, die Income lesen: `applyEconomy` (per-Player End-Turn Wirtschaft), `recomputePlayerStats` (DTO-Sync für Frontend-Anzeige).

## Änderungen

- `GameService.kt`: Filter `&& !it.isSkeleton` im `state.fields.count` von `computeIncome`
- `GameServiceTest.kt`: 3 neue Tests
  - `field income excludes skeleton fields` (gemischtes Setup)
  - `field income is zero when all fields are skeleton` (isolierter Skeleton-Pfad)
  - `recomputePlayerStats income drops when a field becomes skeleton` (Integration mit DTO-Sync)

## Hinweis

Enthält im Branch davor (in `feat/disconnected-fields`) einen Merge-Commit aus main, der das Wirtschafts-Refactoring (#151) reingebracht hat — Voraussetzung, damit `computeIncome` überhaupt existiert.