### PR TITLE
Feat/disconnected fields

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Field.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Field.kt
@@ -10,9 +10,14 @@ package at.aau.hexabrawl.websocketserver.model
  *
  * `owner` ist mutable damit Felder durch Eroberung den Besitzer
  * wechseln koennen (siehe Folge-Sub-Issue #104).
+ *
+ * `isSkeleton` markiert Felder, die vom Hauptgebiet abgeschnitten
+ * wurden. Owner bleibt erhalten fuer Rueckeroberung. Default false;
+ * wird durch recomputeConnectivity gesetzt.
  */
 data class Field(
     val x: Int,
     val y: Int,
-    var owner: String? = null
+    var owner: String? = null,
+    var isSkeleton: Boolean = false
 )

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -404,6 +404,60 @@ class GameService(
         }
     }
 
+    /**
+     * Prueft fuer alle Spieler, ob ihre Felder noch ueber Hex-Nachbarn mit ihrer
+     * BASE verbunden sind. Felder ohne Pfad zur BASE werden zu SKELETON-Feldern,
+     * Einheiten darauf (ausser BASE/SKELETON) werden zu UnitType.SKELETON.
+     *
+     * Spieler ohne BASE-Unit werden uebersprungen — checkWinCondition kuemmert
+     * sich um deren Ausscheiden.
+     */
+    fun recomputeConnectivity(state: GameState) {
+        state.players.forEach { player ->
+            val baseUnit = state.units.firstOrNull {
+                it.player == player.name && it.type == UnitType.BASE
+            } ?: return@forEach
+
+            val connected = bfsConnectedFields(state, player.name, baseUnit.x, baseUnit.y)
+
+            state.fields.filter { it.owner == player.name && !it.isSkeleton }.forEach { field ->
+                if ((field.x to field.y) !in connected) {
+                    field.isSkeleton = true
+                    state.units.filter {
+                        it.x == field.x && it.y == field.y &&
+                            it.player == player.name &&
+                            it.type != UnitType.BASE &&
+                            it.type != UnitType.SKELETON
+                    }.forEach { it.type = UnitType.SKELETON }
+                }
+            }
+        }
+    }
+
+    private fun bfsConnectedFields(
+        state: GameState,
+        playerName: String,
+        startX: Int,
+        startY: Int
+    ): Set<Pair<Int, Int>> {
+        val visited = mutableSetOf(startX to startY)
+        val queue = ArrayDeque<Pair<Int, Int>>()
+        queue.add(startX to startY)
+
+        while (queue.isNotEmpty()) {
+            val (x, y) = queue.removeFirst()
+            for ((nx, ny) in hexNeighbors(x, y)) {
+                if ((nx to ny) in visited) continue
+                val field = state.fields.firstOrNull { it.x == nx && it.y == ny } ?: continue
+                if (field.owner != playerName) continue
+                if (field.isSkeleton) continue
+                visited.add(nx to ny)
+                queue.add(nx to ny)
+            }
+        }
+        return visited
+    }
+
     // WICHTIG FÜR TEST — nur den aktuellen Stand lesen
     fun getCurrentState(state: GameState): GameState = synchronized(state.lock) {
         return state

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -390,8 +390,12 @@ class GameService(
         if (unit in state.units) {
             unit.hasMovedThisTurn = true
             state.fields.firstOrNull { it.x == unit.x && it.y == unit.y }
-                ?.let { it.owner = playerName }
+                ?.let {
+                    it.owner = playerName
+                    it.isSkeleton = false
+                }
         }
+        recomputeConnectivity(state)
         if (allMovableUnitsHaveMoved(state, playerName)) {
             switchTurn(state)
         }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -620,7 +620,7 @@ class GameService(
         return state
     }
     private fun computeIncome(player: Player, state: GameState): Int {
-        val ownedFields = state.fields.count { it.owner == player.name }
+        val ownedFields = state.fields.count { it.owner == player.name && !it.isSkeleton }
         return ownedFields * FIELD_INCOME_PER_ROUND + player.farms * FARM_INCOME_PER_ROUND
     }
 

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConnectivityTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConnectivityTest.kt
@@ -1,0 +1,93 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class FieldConnectivityTest {
+
+    private lateinit var gameService: GameService
+
+    @BeforeEach
+    fun setup() {
+        gameService = GameService(CombatService())
+    }
+
+    private fun stateWithBase(owner: String, baseX: Int, baseY: Int): GameState =
+        GameState().apply {
+            players.add(Player(name = owner))
+            units.add(GameUnit(player = owner, x = baseX, y = baseY, type = UnitType.BASE))
+            fields.add(Field(baseX, baseY, owner = owner))
+        }
+
+    @Test
+    fun `connected territory stays connected`() {
+        val state = stateWithBase("Alice", 0, 0).apply {
+            fields.add(Field(1, 0, owner = "Alice"))
+            fields.add(Field(2, 0, owner = "Alice"))
+        }
+        gameService.recomputeConnectivity(state)
+        assertTrue(state.fields.none { it.isSkeleton })
+    }
+
+    @Test
+    fun `isolated field becomes skeleton`() {
+        val state = stateWithBase("Alice", 0, 0).apply {
+            // (1,0) fehlt – (2,0) hat keinen Pfad zur BASE
+            fields.add(Field(2, 0, owner = "Alice"))
+        }
+        gameService.recomputeConnectivity(state)
+        val baseField = state.fields.first { it.x == 0 && it.y == 0 }
+        val isolated = state.fields.first { it.x == 2 && it.y == 0 }
+        assertFalse(baseField.isSkeleton)
+        assertTrue(isolated.isSkeleton)
+    }
+
+    @Test
+    fun `unit on isolated field becomes skeleton unit`() {
+        val state = stateWithBase("Alice", 0, 0).apply {
+            fields.add(Field(2, 0, owner = "Alice"))
+            units.add(GameUnit(player = "Alice", x = 2, y = 0, type = UnitType.INFANTRY))
+        }
+        gameService.recomputeConnectivity(state)
+        val infantry = state.units.first { it.x == 2 && it.y == 0 }
+        assertEquals(UnitType.SKELETON, infantry.type)
+    }
+
+    @Test
+    fun `narrow corridor keeps territory connected`() {
+        val state = stateWithBase("Alice", 0, 0).apply {
+            // Hex-Kette BASE (0,0) - (1,0) - (2,0) - (3,0) - (4,0)
+            fields.add(Field(1, 0, owner = "Alice"))
+            fields.add(Field(2, 0, owner = "Alice"))
+            fields.add(Field(3, 0, owner = "Alice"))
+            fields.add(Field(4, 0, owner = "Alice"))
+        }
+        gameService.recomputeConnectivity(state)
+        assertTrue(state.fields.none { it.isSkeleton })
+    }
+
+    @Test
+    fun `player without base is skipped without error`() {
+        val state = GameState().apply {
+            players.add(Player(name = "Alice"))
+            // Keine BASE-Unit – Spieler ist via checkWinCondition ohnehin raus
+            fields.add(Field(0, 0, owner = "Alice"))
+            fields.add(Field(1, 0, owner = "Alice"))
+        }
+        gameService.recomputeConnectivity(state)
+        assertTrue(state.fields.none { it.isSkeleton })
+    }
+
+    @Test
+    fun `skeleton corridor blocks bfs path`() {
+        val state = stateWithBase("Alice", 0, 0).apply {
+            // (1,0) ist Alice aber bereits SKELETON – sollte als Pfad nicht zählen
+            fields.add(Field(1, 0, owner = "Alice", isSkeleton = true))
+            fields.add(Field(2, 0, owner = "Alice"))
+        }
+        gameService.recomputeConnectivity(state)
+        val field20 = state.fields.first { it.x == 2 && it.y == 0 }
+        assertTrue(field20.isSkeleton)
+    }
+}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConnectivityTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConnectivityTest.kt
@@ -90,4 +90,65 @@ class FieldConnectivityTest {
         val field20 = state.fields.first { it.x == 2 && it.y == 0 }
         assertTrue(field20.isSkeleton)
     }
+
+    @Test
+    fun `own player recaptures own skeleton field via handleMove`() {
+        val state = GameState().apply {
+            status = GameStatus.IN_PROGRESS
+            currentTurn = "Alice"
+            players.add(Player(name = "Alice"))
+            units.add(GameUnit(player = "Alice", x = 0, y = 0, type = UnitType.BASE))
+            units.add(GameUnit(player = "Alice", x = 1, y = 0, type = UnitType.INFANTRY))
+            // Zweite Einheit, damit allMovableUnitsHaveMoved nicht gleich switchTurn triggert
+            units.add(GameUnit(player = "Alice", x = 0, y = 1, type = UnitType.CAVALRY))
+            fields.add(Field(0, 0, owner = "Alice"))
+            fields.add(Field(1, 0, owner = "Alice"))
+            fields.add(Field(2, 0, owner = "Alice", isSkeleton = true))
+        }
+
+        gameService.handleMove(state, Move(
+            player = "Alice",
+            type = UnitType.INFANTRY,
+            fromX = 1, fromY = 0,
+            toX = 2, toY = 0
+        ))
+
+        val recaptured = state.fields.first { it.x == 2 && it.y == 0 }
+        assertEquals("Alice", recaptured.owner)
+        assertFalse(recaptured.isSkeleton)
+        assertTrue(state.units.any {
+            it.player == "Alice" && it.type == UnitType.INFANTRY && it.x == 2 && it.y == 0
+        })
+    }
+
+    @Test
+    fun `opponent captures skeleton field via handleMove`() {
+        val state = GameState().apply {
+            status = GameStatus.IN_PROGRESS
+            currentTurn = "Bob"
+            players.add(Player(name = "Alice"))
+            players.add(Player(name = "Bob"))
+            units.add(GameUnit(player = "Alice", x = 0, y = 0, type = UnitType.BASE))
+            units.add(GameUnit(player = "Bob", x = 3, y = 0, type = UnitType.INFANTRY))
+            // Zweite Bob-Einheit, damit allMovableUnitsHaveMoved nicht gleich switchTurn triggert
+            units.add(GameUnit(player = "Bob", x = 4, y = 1, type = UnitType.CAVALRY))
+            fields.add(Field(0, 0, owner = "Alice"))
+            fields.add(Field(2, 0, owner = "Alice", isSkeleton = true))
+            fields.add(Field(3, 0, owner = "Bob"))
+        }
+
+        gameService.handleMove(state, Move(
+            player = "Bob",
+            type = UnitType.INFANTRY,
+            fromX = 3, fromY = 0,
+            toX = 2, toY = 0
+        ))
+
+        val captured = state.fields.first { it.x == 2 && it.y == 0 }
+        assertEquals("Bob", captured.owner)
+        assertFalse(captured.isSkeleton)
+        assertTrue(state.units.any {
+            it.player == "Bob" && it.type == UnitType.INFANTRY && it.x == 2 && it.y == 0
+        })
+    }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldTest.kt
@@ -102,4 +102,19 @@ class FieldTest {
             }
         }
     }
+
+    @Test
+    fun `new field has isSkeleton false by default`() {
+        val field = Field(x = 0, y = 0)
+        assertFalse(field.isSkeleton)
+    }
+
+    @Test
+    fun `isSkeleton can be toggled at runtime`() {
+        val field = Field(x = 0, y = 0)
+        field.isSkeleton = true
+        assertTrue(field.isSkeleton)
+        field.isSkeleton = false
+        assertFalse(field.isSkeleton)
+    }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -639,6 +639,65 @@ class GameServiceTest {
     }
 
     @Test
+    fun `field income excludes skeleton fields`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            status = GameStatus.IN_PROGRESS
+            currentTurn = "Alice"
+
+            players.add(Player(name = "Alice", gold = 0, farms = 0))
+            // 3 Felder, davon 1 SKELETON
+            fields.add(Field(0, 0, owner = "Alice"))
+            fields.add(Field(0, 1, owner = "Alice"))
+            fields.add(Field(0, 2, owner = "Alice", isSkeleton = true))
+        }
+
+        service.endTurn(state, "Alice")
+
+        // Nur 2 von 3 Feldern zaehlen
+        assertEquals(2, state.players[0].gold)
+    }
+
+    @Test
+    fun `field income is zero when all fields are skeleton`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            status = GameStatus.IN_PROGRESS
+            currentTurn = "Alice"
+
+            players.add(Player(name = "Alice", gold = 0, farms = 1))
+            fields.addAll(List(3) { Field(0, it, owner = "Alice", isSkeleton = true) })
+        }
+
+        service.endTurn(state, "Alice")
+
+        // Nur Farm-Income (1 × 3 = 3), kein Feld-Income
+        assertEquals(3, state.players[0].gold)
+    }
+
+    @Test
+    fun `recomputePlayerStats income drops when a field becomes skeleton`() {
+        val service = GameService(CombatService())
+        val state = GameState().apply {
+            players.add(Player(name = "Alice", farms = 0))
+            fields.add(Field(0, 0, owner = "Alice"))
+            fields.add(Field(0, 1, owner = "Alice"))
+            fields.add(Field(0, 2, owner = "Alice"))
+        }
+
+        service.recomputePlayerStats(state)
+        val incomeBefore = state.players[0].income
+
+        // Eines der Felder wird abgeschnitten
+        state.fields[1].isSkeleton = true
+        service.recomputePlayerStats(state)
+        val incomeAfter = state.players[0].income
+
+        assertEquals(3, incomeBefore)
+        assertEquals(2, incomeAfter)
+    }
+
+    @Test
     fun `recomputePlayerStats sets income from fields and farms`() {
         val service = GameService(CombatService())
         val state = GameState().apply {


### PR DESCRIPTION
Komplettes Feature für abgeschnittene Gebiete: wenn ein gegnerischer Spieler den Hex-Pfad zwischen einem Feld und der zugehörigen BASE unterbricht, wird das isolierte Feld zu einem SKELETON-Feld. Einheiten darauf werden zu `UnitType.SKELETON`, Income aus dem Feld entfällt. Rückeroberung beim Drauf-Ziehen einer Einheit hebt den SKELETON-Status auf.

## Sub-Issues

Drei aufeinander aufbauende Sub-Issues, alle bereits in dieses Parent gemerged:

1. **#<sub-1>** `Field.isSkeleton` einführen — Datenstruktur
2. **#<sub-2>** BFS-Connectivity-Check + Trigger nach `handleMove` — Logik
3. **#<sub-3>** Income-Filter für SKELETON-Felder — Wirtschafts-Anbindung (depends on #151)

## Spec

- **Connectivity-Definition:** Feld F ist verbunden zur BASE von Spieler P, wenn ein Hex-Pfad existiert, der nur über Felder mit `owner == P.name && !isSkeleton` läuft und an der BASE-Unit endet.
- **Trigger:** `recomputeConnectivity(state)` läuft in `finishMove`, nach jedem `handleMove` (Combat-Pfad enthalten). Prüft alle Spieler global.
- **Effekt bei Abschneidung:** `Field.isSkeleton = true`, alle nicht-BASE-nicht-SKELETON-Einheiten auf dem Feld → `UnitType.SKELETON`.
- **Rückeroberung:** Einheit zieht auf SKELETON-Feld → `isSkeleton = false`, `owner = mover.name`.
- **Wirtschaft:** SKELETON-Felder geben kein Gold (Filter in `computeIncome`).
- **Edge-Case:** Spieler ohne BASE-Unit → übersprungen (`checkWinCondition` regelt das).

## Änderungen (kumuliert)

- `Field.kt`: neue Property `var isSkeleton: Boolean = false`
- `GameService.kt`:
  - Public-Methode `recomputeConnectivity(state)`
  - Privater BFS-Helper `bfsConnectedFields`
  - `finishMove` ruft `recomputeConnectivity` und setzt `isSkeleton = false` bei Eroberung
  - `computeIncome` schließt SKELETON-Felder aus
- `FieldTest.kt`: 2 Tests (Default + Mutability)
- `FieldConnectivityTest.kt` (neu): 8 Tests — Connectivity-Logik + handleMove-Integration
- `GameServiceTest.kt`: 3 Tests für Income-Filter

## Akzeptanzkriterien

- [x] Datenstruktur `Field.isSkeleton` mit Default `false`
- [x] BFS-Connectivity ab BASE-Unit, transitiv über eigene Nicht-SKELETON-Felder
- [x] Trigger nach jedem `handleMove` (Combat-Pfad mitabgedeckt via `finishMove`)
- [x] Einheiten auf abgeschnittenen Feldern → SKELETON, BASE bleibt unverändert
- [x] Rückeroberung durch eigenen Spieler und durch Gegner
- [x] Spieler ohne BASE wird übersprungen, kein Crash
- [x] `computeIncome` filtert SKELETON-Felder
- [x] Bestehende Tests grün, neue Tests pro Sub-Issue ergänzt
- [x] Keine Verhaltensänderung am Wirtschafts-Refactoring (#151) — baut darauf auf

## Tests

`./mvnw test -DskipITs` mit Java 25:
- FieldTest: 10/10
- FieldConnectivityTest: 8/8
- GameServiceTest: alle grün, davon 3 neue für Income-Filter
- Gesamt: 283 Unit-Tests grün, 5 IT-Errors = bekannter Windows-`WEPollSelectorImpl`-Bug, kein Bezug zu diesem PR

## Out of Scope

- **Frontend-Grau-Darstellung** der SKELETON-Felder → separates App-Issue
- **`handleDisconnect`-Cleanup** für verwaiste Felder eines disconnecteten Spielers → separates Issue
- **Reconnect-Feature** → Post-Sprint-3-Thema

## Hinweise zur History

- Sub-Issue 1 wurde via Merge-Commit gemerged (sichtbar als #160)
- Sub-Issue 2 dito (Merge-Commit + Detail-Commits + ein Sync-Merge-Commit aus dem Integration-Branch)
- Sub-Issue 3 ist 1-Zeilen-Production + 3 Tests + 1 Merge-Commit aus main (für das Wirtschafts-Refactoring #151, das `computeIncome` einführt)
- Alle Detail-Commits sind in main sichtbar (kein Squash)