### PR TITLE
Feat/schummelfunktion cheat geschenk feature pending gift

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameState.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameState.kt
@@ -14,7 +14,8 @@ data class GameState(
     var currentTurn: String? = null,
     var status: GameStatus = GameStatus.WAITING_FOR_PLAYERS,
     var gameMode: GameMode = GameMode.DUAL_VALLEY,
-    var winner: String? = null
+    var winner: String? = null,
+    var pendingGift: PendingGift? = null
 )
 {
     @JsonIgnore

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Player.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/Player.kt
@@ -8,5 +8,6 @@ data class Player (
     var gold: Int = 0,
     var farms: Int = 0,
     var income: Int = 0,
-    var upkeep: Int = 0
+    var upkeep: Int = 0,
+    var hasUsedGift: Boolean = false
 ){}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameStateTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameStateTest.kt
@@ -95,5 +95,19 @@ class GameStateTest {
         Assertions.assertEquals(GameStatus.WAITING_FOR_PLAYERS, gameState.status)
     }
 
+    @Test
+    fun `game state starts with pendingGift null`() {
+        Assertions.assertNull(gameState.pendingGift)
+    }
 
+    @Test
+    fun `pendingGift can be assigned and cleared`() {
+        gameState.pendingGift = PendingGift(ownerName = "Alice", delta = 5, pendingDecisions = 2)
+        Assertions.assertEquals("Alice", gameState.pendingGift?.ownerName)
+        Assertions.assertEquals(5, gameState.pendingGift?.delta)
+        Assertions.assertEquals(2, gameState.pendingGift?.pendingDecisions)
+
+        gameState.pendingGift = null
+        Assertions.assertNull(gameState.pendingGift)
+    }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/PlayerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/PlayerTest.kt
@@ -1,6 +1,8 @@
 package at.aau.hexabrawl.websocketserver.model
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import tools.jackson.databind.ObjectMapper
 
@@ -20,5 +22,18 @@ class PlayerTest {
         val player = Player(name = "Alice")
         assertEquals(0, player.income)
         assertEquals(0, player.upkeep)
+    }
+
+    @Test
+    fun `new player has hasUsedGift false by default`() {
+        val player = Player(name = "Alice")
+        assertFalse(player.hasUsedGift)
+    }
+
+    @Test
+    fun `hasUsedGift can be toggled at runtime`() {
+        val player = Player(name = "Alice")
+        player.hasUsedGift = true
+        assertTrue(player.hasUsedGift)
     }
 }


### PR DESCRIPTION
Ergänzt `Player.hasUsedGift: Boolean = false` und `GameState.pendingGift: PendingGift? = null`. Defaults → keine Verhaltensänderung. Wird in Sub-Issue 4 (claim-gift) gesetzt.

Plus Merge-Commit aus Parent für die `PendingGift`-Datenklasse (Typ-Voraussetzung).