### PR TITLE
Fix #189: Verhindern der Einheiten-Platzierung auf abgeschnittenen Feldern (Skelett-Feldern)

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -311,6 +311,16 @@ class WebSocketBrokerController(
             return null
         }
 
+        // Zielfeld darf kein Skelett-Feld (abgeschnitten) sein
+        if (field.isSkeleton) {
+            sendError(
+                sessionId,
+                ErrorCode.INVALID_PLACEMENT,
+                "Einheit kann nicht auf abgeschnittenen Feldern platziert werden."
+            )
+            return null
+        }
+
         // Zielfeld darf nicht von eigener Einheit (inkl. BASE) besetzt sein.
         // Skelette zaehlen nicht als "besetzt" — werden vom Service entfernt.
         val occupiedByOwn = state.units.any {

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -1315,4 +1315,46 @@ class WebSocketBrokerControllerTest {
         assertTrue(state.units.none { it.hasMovedThisTurn })
         assertEquals("Bob", state.currentTurn)
     }
+
+    @Test
+    fun `buyUnitRoom sends INVALID_PLACEMENT if target field is a skeleton`() {
+        val room = roomRegistry.createRoom(GameMode.DUAL_VALLEY)
+        room.gameState.status = GameStatus.IN_PROGRESS
+        room.gameState.currentTurn = "Alice"
+
+        val alice = Player("Alice", "test-session", gold = 50)
+        room.gameState.players.add(alice)
+
+        // Setup: Das Zielfeld gehört Alice, ist aber eine tote Zone (isSkeleton = true)
+        room.gameState.fields.add(Field(x = 2, y = 2, owner = "Alice", isSkeleton = true))
+
+        val request = BuyUnitRequest(
+            playerName = "Alice",
+            type = UnitType.INFANTRY,
+            x = 2,
+            y = 2
+        )
+
+        // Ausführung
+        val result = controller.buyUnitRoom(room.roomId, request, headerAccessor)
+
+        // Assertions
+        assertNull(result) // Kauf muss abgebrochen werden
+
+        // Prüfen, dass das Gold NICHT abgezogen wurde
+        assertEquals(50, alice.gold)
+
+        // Prüfen, dass KEINE Einheit platziert wurde
+        assertTrue(room.gameState.units.none { it.x == 2 && it.y == 2 && it.type == UnitType.INFANTRY })
+
+        // Prüfen, dass die korrekte INVALID_PLACEMENT Fehlermeldung an den Client gesendet wurde
+        verify(messagingTemplate).convertAndSendToUser(
+            eq("test-session"),
+            eq("/queue/errors"),
+            argThat {
+                it is ErrorMessage &&
+                        it.errorCode == ErrorCode.INVALID_PLACEMENT
+            }
+        )
+    }
 }


### PR DESCRIPTION
**Problem / Kontext**

Wenn die Verbindung von eigenen Feldern zur Hauptbasis unterbrochen wird, markiert das Backend diese Felder als tote Zonen (`isSkeleton = true`). Bisher prüfte der `buyUnitRoom`-Endpoint beim Kauf neuer Einheiten jedoch ausschließlich, ob das Zielfeld dem Spieler gehört (`owner == playerName`). Da der Besitzer bei abgeschnittenen Feldern nicht gelöscht wird, war es fälschlicherweise möglich, neue Einheiten direkt in diesen vom Nachschub abgeschnittenen Zonen zu rekrutieren.

**Lösung / Umsetzung**

* **Zusätzliche Validierung:** In der "billig vor teuer"-Kette der `buyUnitRoom`-Methode wird nun geprüft, ob das anvisierte Feld das Attribut `isSkeleton == true` besitzt.
* **Edge-Cases abgedeckt:** Da die Eigenschaft direkt am Feld (und nicht an einer darauf stehenden Einheit) geprüft wird, blockiert das System nun auch das Platzieren auf *leeren* Feldern, die von der Basis abgeschnitten wurden.
* **Fehlerbehandlung:** Bei einem Verstoß wird der Kauf sofort abgebrochen und der Client erhält einen `INVALID_PLACEMENT` Error.
* **Testing:** Ein dedizierter Unit-Test in `WebSocketBrokerControllerTest` stellt sicher, dass der Kauf abgelehnt wird, die Einheit nicht erscheint und dem Spieler korrekterweise kein Gold abgezogen wird.

Closes #189