### PR TITLE
Feat/reconnect soft disconnect

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -528,22 +528,40 @@ class GameService(
     fun resetToStartCondition(): GameState = resetToStartCondition(this.gameState)
 
     /**
-     * Entfernt einen disconnecteten Spieler und seine Einheiten.
-     *
-     *  - DUAL_VALLEY: checkWinCondition (BASE-basiert)
-     *  - TRIAD/BATTLEFIELD: Fallback — Disconnect beendet das Spiel sofort
+     * Soft-Disconnect: markiert den Spieler als nicht-verbunden und merkt
+     * sich den Zeitpunkt. Spieler, Units und Felder bleiben unverändert,
+     * sodass ein /reconnect binnen Grace Period nahtlos wieder einsteigen
+     * kann. Der eigentliche Hard-Delete passiert via [hardDelete] —
+     * aufgerufen vom Scheduled Cleanup (nach Grace) oder vom /leave-Endpoint
+     * (sofort).
      */
     fun handleDisconnect(state: GameState, sessionId: String): GameState = synchronized(state.lock) {
-        val player = state.players.find { it.sessionId == sessionId }
-            ?: return state
+        val player = state.players.find { it.sessionId == sessionId } ?: return state
+        player.connected = false
+        player.disconnectedAt = System.currentTimeMillis()
+        println("Service: SOFT DISCONNECT - ${player.name}")
+        return state
+    }
 
+    /**
+     * Hard-Delete eines Spielers (Variante B2).
+     *
+     * Wird aufgerufen, wenn die Grace Period abgelaufen ist (Scheduled Cleanup)
+     * oder ein Spieler explizit /leave drueckt.
+     *
+     * Verhalten:
+     *  - Aktives pendingGift aufraeumen (war frueher in handleDisconnect)
+     *  - Felder werden neutral (owner = null), Units komplett geloescht,
+     *    currentTurn weitergereicht — alles via [eliminatePlayer]
+     *  - checkWinCondition laeuft (1 Player mit BASE uebrig → Win)
+     *  - KEIN FINISHED-Fallback fuer TRIAD/BATTLEFIELD (wurde schon entfernt)
+     */
+    internal fun hardDelete(state: GameState, player: Player): Unit = synchronized(state.lock) {
         // Aktives Cheat-Geschenk aufraeumen, falls der disconnectete Spieler beteiligt war
         state.pendingGift?.let { gift ->
             if (gift.ownerName == player.name) {
-                // Owner ist weg — Geschenk abbrechen
                 state.pendingGift = null
             } else {
-                // Stealer-Kandidat weg — eine Entscheidung weniger
                 val remaining = gift.pendingDecisions - 1
                 state.pendingGift = if (remaining > 0) {
                     gift.copy(pendingDecisions = remaining)
@@ -553,19 +571,14 @@ class GameService(
             }
         }
 
-        println("Service: PLAYER LEFT - ${player.name} disconnected")
+        println("Service: HARD DELETE - ${player.name}")
 
-        // Den Spieler sauber eliminieren (Felder neutralisieren, Zugweitergabe, etc.)
         eliminatePlayer(state, player.name)
-
-        // Prüfen, ob durch den Disconnect jetzt ein Sieger feststeht (z.B. nur noch 1 Spieler übrig)
         checkWinCondition(state)
 
         if (state.status == GameStatus.FINISHED) {
             println("Service: GAME FINISHED - winner: ${state.winner}")
         }
-
-        return state
     }
 
     fun handleDisconnect(sessionId: String): GameState = handleDisconnect(this.gameState, sessionId)

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerComponentTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerComponentTest.kt
@@ -1,6 +1,7 @@
 package at.aau.hexabrawl.websocketserver.model
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
@@ -45,20 +46,18 @@ class DisconnectHandlerComponentTest {
     }
 
     @Test
-    fun `handleDisconnect removes player from game`() {
-
-        val room = roomRegistry.createRoom(
-            GameMode.DUAL_VALLEY
-        )
-
-        gameService.handleJoin(room.gameState,"Alice", "session-1")
+    fun `handleDisconnect marks player as not connected but keeps them`() {
+        val room = roomRegistry.createRoom(GameMode.DUAL_VALLEY)
+        gameService.handleJoin(room.gameState, "Alice", "session-1")
 
         val event = Mockito.mock(SessionDisconnectEvent::class.java)
         Mockito.`when`(event.sessionId).thenReturn("session-1")
 
         handler.handleDisconnect(event)
 
-        assertEquals(0, room.gameState.players.size)
+        // Soft-Disconnect: Player bleibt im State waehrend Grace Period
+        assertEquals(1, room.gameState.players.size)
+        assertFalse(room.gameState.players.first().connected)
     }
 
     @Test
@@ -113,20 +112,14 @@ class DisconnectHandlerComponentTest {
 
         handler.handleDisconnect(event)
 
-        assertEquals(
-            2,
-            room1.gameState.players.size
-        )
-
-        assertEquals(
-            1,
-            room2.gameState.players.size
-        )
-
-        assertEquals(
-            "Dave",
-            room2.gameState.players.first().name
-        )
+        // Soft-Disconnect: room2.Charlie wurde markiert, nicht entfernt
+        assertEquals(2, room1.gameState.players.size)
+        assertEquals(2, room2.gameState.players.size)
+        assertFalse(room2.gameState.players.first { it.name == "Charlie" }.connected)
+        // Andere Spieler in room2 sind unbeeinflusst
+        assertEquals(true, room2.gameState.players.first { it.name == "Dave" }.connected)
+        // room1 ist komplett unbeeinflusst
+        assertEquals(true, room1.gameState.players.first { it.name == "Alice" }.connected)
     }
 
     @Test
@@ -164,64 +157,36 @@ class DisconnectHandlerComponentTest {
     }
 
     @Test
-    fun `disconnect sets only affected room to FINISHED`() {
+    fun `soft disconnect does not change status of either room`() {
+        val room1 = roomRegistry.createRoom(GameMode.DUAL_VALLEY)
+        val room2 = roomRegistry.createRoom(GameMode.DUAL_VALLEY)
+        gameService.handleJoin(room1.gameState, "Alice", "session-1")
+        gameService.handleJoin(room1.gameState, "Bob", "session-2")
+        gameService.handleJoin(room2.gameState, "Charlie", "session-3")
+        gameService.handleJoin(room2.gameState, "Dave", "session-4")
 
-        val room1 = roomRegistry.createRoom(
-            GameMode.DUAL_VALLEY
-        )
+        assertEquals(GameStatus.IN_PROGRESS, room1.gameState.status)
+        assertEquals(GameStatus.IN_PROGRESS, room2.gameState.status)
 
-        val room2 = roomRegistry.createRoom(
-            GameMode.DUAL_VALLEY
-        )
+        gameService.handleDisconnect(room2.gameState, "session-3")
 
-        gameService.handleJoin(
-            room1.gameState,
-            "Alice",
-            "session-1"
-        )
-
-        gameService.handleJoin(
-            room1.gameState,
-            "Bob",
-            "session-2"
-        )
-
-        gameService.handleJoin(
-            room2.gameState,
-            "Charlie",
-            "session-3"
-        )
-
-        gameService.handleJoin(
-            room2.gameState,
-            "Dave",
-            "session-4"
-        )
-
-        assertEquals(
-            GameStatus.IN_PROGRESS,
-            room1.gameState.status
-        )
-
-        assertEquals(
-            GameStatus.IN_PROGRESS,
-            room2.gameState.status
-        )
-
-        gameService.handleDisconnect(
-            room2.gameState,
-            "session-3"
-        )
-
-        assertEquals(
-            GameStatus.IN_PROGRESS,
-            room1.gameState.status
-        )
-
-        assertEquals(
-            GameStatus.FINISHED,
-            room2.gameState.status
-        )
+        // Soft-Disconnect: kein Statuswechsel — der passiert erst beim hardDelete
+        assertEquals(GameStatus.IN_PROGRESS, room1.gameState.status)
+        assertEquals(GameStatus.IN_PROGRESS, room2.gameState.status)
     }
 
+    @Test
+    fun `hardDelete in DUAL_VALLEY sets status to FINISHED`() {
+        val room = roomRegistry.createRoom(GameMode.DUAL_VALLEY)
+        gameService.handleJoin(room.gameState, "Alice", "session-1")
+        gameService.handleJoin(room.gameState, "Bob", "session-2")
+
+        val alice = room.gameState.players.first { it.name == "Alice" }
+        gameService.hardDelete(room.gameState, alice)
+
+        // Bob ist letzter mit BASE → Win
+        assertEquals(GameStatus.FINISHED, room.gameState.status)
+        assertEquals("Bob", room.gameState.winner)
+        assertEquals(1, room.gameState.players.size)
+    }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerTest.kt
@@ -13,10 +13,46 @@ class DisconnectHandlerTest {
         gameService = GameService(CombatService())
     }
 
+    /**
+     * Test-Helper: simuliert die kombinierte Soft+Hard-Disconnect-Sequenz
+     * (handleDisconnect markiert, hardDelete macht endgueltig). Im echten
+     * Code passiert das durch den Scheduled Cleanup nach 30s Grace.
+     */
+    private fun forceDisconnect(sessionId: String) {
+        val state = gameService.gameState
+        val player = state.players.find { it.sessionId == sessionId } ?: return
+        gameService.handleDisconnect(sessionId)
+        gameService.hardDelete(state, player)
+    }
+
+    @Test
+    fun `handleDisconnect alone only marks player as not connected`() {
+        gameService.handleJoin("Alice", "session-1")
+        gameService.handleJoin("Bob", "session-2")
+
+        gameService.handleDisconnect("session-1")
+
+        val alice = gameService.gameState.players.first { it.name == "Alice" }
+        assertFalse(alice.connected)
+        assertNotNull(alice.disconnectedAt)
+        // Player bleibt im State waehrend Grace Period
+        assertEquals(2, gameService.gameState.players.size)
+    }
+
+    @Test
+    fun `handleDisconnect with unknown sessionId is no-op for soft disconnect`() {
+        gameService.handleJoin("Alice", "session-1")
+        gameService.handleDisconnect("unknown-session")
+
+        assertEquals(1, gameService.gameState.players.size)
+        val alice = gameService.gameState.players.first { it.name == "Alice" }
+        assertTrue(alice.connected)
+    }
+
     @Test
     fun `disconnect during WAITING_FOR_PLAYERS removes player`() {
         gameService.handleJoin("Alice", "session-1")
-        gameService.handleDisconnect("session-1")
+        forceDisconnect("session-1")
 
         assertEquals(0, gameService.gameState.players.size)
         assertEquals(GameStatus.WAITING_FOR_PLAYERS, gameService.gameState.status)
@@ -29,7 +65,7 @@ class DisconnectHandlerTest {
 
         assertEquals(GameStatus.IN_PROGRESS, gameService.gameState.status)
 
-        gameService.handleDisconnect("session-1")
+        forceDisconnect("session-1")
 
         assertEquals(GameStatus.FINISHED, gameService.gameState.status)
     }
@@ -39,7 +75,7 @@ class DisconnectHandlerTest {
         gameService.handleJoin("Alice", "session-1")
         gameService.handleJoin("Bob", "session-2")
 
-        gameService.handleDisconnect("session-1")
+        forceDisconnect("session-1")
 
         val aliceUnits = gameService.gameState.units.filter { it.player == "Alice" }
         assertEquals(0, aliceUnits.size)
@@ -58,7 +94,7 @@ class DisconnectHandlerTest {
         gameService.handleJoin("Alice", "session-1")
         gameService.handleJoin("Bob", "session-2")
 
-        gameService.handleDisconnect("session-1")
+        forceDisconnect("session-1")
 
         assertNull(gameService.gameState.currentTurn)
     }
@@ -76,7 +112,7 @@ class DisconnectHandlerTest {
         s.units.add(GameUnit("Bob", 7, 8, UnitType.INFANTRY))
         s.units.add(GameUnit("Bob", 6, 7, UnitType.CAVALRY))
 
-        gameService.handleDisconnect("session-1")
+        forceDisconnect("session-1")
 
         // 3 regulaere Einheiten (ARCHER, INFANTRY, CAVALRY) + 1 BASE pro Spieler.
         val bobUnits = gameService.gameState.units.filter { it.player == "Bob" }
@@ -88,7 +124,7 @@ class DisconnectHandlerTest {
         gameService.handleJoin("Alice", "session-1")
         gameService.handleJoin("Bob", "session-2")
 
-        gameService.handleDisconnect("session-1")
+        forceDisconnect("session-1")
 
         val state = gameService.gameState
         assertEquals(GameStatus.FINISHED, state.status)
@@ -105,7 +141,7 @@ class DisconnectHandlerTest {
         // Einheiten auf dem Brett hat -> Unentschieden
         gameService.gameState.units.removeIf { it.player == "Bob" }
 
-        gameService.handleDisconnect("session-1")
+        forceDisconnect("session-1")
 
         val state = gameService.gameState
         assertEquals(GameStatus.FINISHED, state.status)

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
@@ -200,47 +200,31 @@ class GameModelTest {
 
     @Test
     fun `handleDisconnect only modifies provided state`() {
-
         val gameService = GameService(CombatService())
-
         val state1 = GameState()
         val state2 = GameState()
 
-        gameService.handleJoin(
-            state1,
-            "Josef",
-            "s1"
-        )
+        gameService.handleJoin(state1, "Josef", "s1")
+        gameService.handleDisconnect(state1, "s1")
 
-        gameService.handleDisconnect(
-            state1,
-            "s1"
-        )
-
-        assertTrue(state1.players.isEmpty())
+        // Soft-Disconnect: Josef bleibt im state1, aber connected = false
+        assertEquals(1, state1.players.size)
+        assertFalse(state1.players.first().connected)
+        // state2 ist komplett unbeeinflusst
         assertTrue(state2.players.isEmpty())
-
-        assertEquals(
-            GameStatus.WAITING_FOR_PLAYERS,
-            state2.status
-        )
+        assertEquals(GameStatus.WAITING_FOR_PLAYERS, state2.status)
     }
 
     @Test
     fun `legacy handleDisconnect bridge still uses gameState`() {
-
         val gameService = GameService(CombatService())
 
-        gameService.handleJoin(
-            "Josef",
-            "s1"
-        )
-
+        gameService.handleJoin("Josef", "s1")
         gameService.handleDisconnect("s1")
 
-        assertTrue(
-            gameService.gameState.players.isEmpty()
-        )
+        // Soft-Disconnect: Josef bleibt, ist nur als nicht-verbunden markiert
+        assertEquals(1, gameService.gameState.players.size)
+        assertFalse(gameService.gameState.players.first().connected)
     }
 
     @Test

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -1058,7 +1058,7 @@ class GameServiceTest {
     }
 
     @Test
-    fun `handleDisconnect clears pendingGift when owner disconnects`() {
+    fun `hardDelete clears pendingGift when owner disconnects`() {
         val service = GameService(CombatService())
         val state = GameState().apply {
             gameMode = GameMode.TRIAD_OUTPOST
@@ -1076,13 +1076,15 @@ class GameServiceTest {
             pendingGift = PendingGift(ownerName = "Alice", delta = 5, pendingDecisions = 2)
         }
 
+        val alice = state.players.first { it.name == "Alice" }
         service.handleDisconnect(state, "sess-alice")
+        service.hardDelete(state, alice)
 
         assertNull(state.pendingGift)
     }
 
     @Test
-    fun `handleDisconnect decrements pendingDecisions when stealer disconnects`() {
+    fun `hardDelete decrements pendingDecisions when stealer disconnects`() {
         val service = GameService(CombatService())
         val state = GameState().apply {
             gameMode = GameMode.TRIAD_OUTPOST
@@ -1100,14 +1102,16 @@ class GameServiceTest {
             pendingGift = PendingGift(ownerName = "Alice", delta = 5, pendingDecisions = 2)
         }
 
+        val bob = state.players.first { it.name == "Bob" }
         service.handleDisconnect(state, "sess-bob")
+        service.hardDelete(state, bob)
 
         assertNotNull(state.pendingGift)
         assertEquals(1, state.pendingGift?.pendingDecisions)
     }
 
     @Test
-    fun `handleDisconnect clears pendingGift when last stealer disconnects`() {
+    fun `hardDelete clears pendingGift when last stealer disconnects`() {
         val service = GameService(CombatService())
         val state = GameState().apply {
             gameMode = GameMode.TRIAD_OUTPOST
@@ -1123,7 +1127,9 @@ class GameServiceTest {
             pendingGift = PendingGift(ownerName = "Alice", delta = 5, pendingDecisions = 1)
         }
 
+        val bob = state.players.first { it.name == "Bob" }
         service.handleDisconnect(state, "sess-bob")
+        service.hardDelete(state, bob)
 
         assertNull(state.pendingGift)
     }
@@ -1189,8 +1195,11 @@ class GameServiceTest {
             fields.add(Field(1, 1).apply { owner = "Bob" })
         }
 
-        // Aktion: Bob hat einen Disconnect
+        // Aktion: Bob hat einen Disconnect — wir simulieren die volle Sequenz
+        // (Soft-Disconnect markiert, dann Hard-Delete nach Grace).
+        val bob = state.players.first { it.sessionId == "s2" }
         service.handleDisconnect(state, "s2")
+        service.hardDelete(state, bob)
 
         // Assertions
         assertEquals(2, state.players.size)


### PR DESCRIPTION
## Was

`handleDisconnect` markiert jetzt nur noch (`connected = false`, `disconnectedAt`). Das alte Hard-Delete-Verhalten (pendingGift-Cleanup, `eliminatePlayer`, `checkWinCondition`) wandert in `internal fun hardDelete(state, player)` — wird vom Scheduled Cleanup nach 30s Grace (Sub-Issue 5) und vom `/leave`-Endpoint (Sub-Issue 6) aufgerufen.

Felder-Neutralisierung (Variante B2) ist bereits in `eliminatePlayer` enthalten, FINISHED-Fallback für TRIAD/BATTLEFIELD ist schon raus.

## Warum bestehende Tests anpassen

15 Tests in 4 Files haben vorher gegen handleDisconnect direkt geprüft, dass:
- Player gelöscht wird (`players.size == 0`)
- Status auf FINISHED geht
- pendingGift aufgeräumt wird

Mit Soft-Disconnect passiert das alles erst beim `hardDelete`-Aufruf — also stimmen die alten Erwartungen nicht mehr direkt nach `handleDisconnect`. Lösung pro Test:

- **Wenn das alte Hard-Delete-Verhalten gemeint war** → `handleDisconnect` + `hardDelete` hintereinander aufrufen (in `DisconnectHandlerTest` mit `forceDisconnect`-Helper, in `GameServiceTest` explizit pro Test).
- **Wenn der Test sinnvoller die neue Soft-Semantik prüfen sollte** → umformuliert auf `connected = false` + Player bleibt.

Plus zusätzliche Tests für die reine Soft-Disconnect-Semantik und einen expliziten `hardDelete`-Test.
