### PR TITLE
Chore #205: Docker Compose Resource Limits für Server-Container einrichten

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,11 @@ services:
     restart: unless-stopped
     ports:
       - "53216:8080"
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 2048M
+        reservations:
+          cpus: "0.5"
+          memory: 768M


### PR DESCRIPTION
**Problem / Kontext**
Bisher lief der Server-Container (`ghcr.io/hexabrawl/server:latest`) in unserer Infrastruktur ohne explizite Hardware-Grenzen. Um die Stabilität des Host-Systems zu gewährleisten und unkontrollierte Ressourcen-Auslastungen durch den Container zu verhindern, mussten feste Zuweisungen für CPU und Arbeitsspeicher definiert werden.

**Lösung / Umsetzung**
Dieser PR ergänzt die `docker-compose.yml` um einen `deploy`-Block mit entsprechenden Ressourcen-Regeln für den Server-Service:
* **Limits:** Die maximale Auslastung wurde auf harte Grenzen von `2.0` CPUs und `2048M` (2 GB) RAM limitiert, um das restliche System zu schützen.
* **Reservations:** Es wurden garantierte Mindestressourcen von `0.5` CPUs und `768M` RAM reserviert, um einen durchgehend flüssigen und vorhersehbaren Betrieb der Java/Spring-Anwendung sicherzustellen.

**Testing**
* Reine Konfigurationsänderung an der Infrastruktur (keine Unit-Tests notwendig).
* Die YAML-Einrückungen und die Syntax sind valide.
* Die bestehende Konfiguration (Ports, Image, Restart-Policy) blieb unangetastet.

Closes #205