### PR TITLE
Refactor #208: ConnectivityService extrahieren & Test-Infrastruktur vorbereiten

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/ConnectivityService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/ConnectivityService.kt
@@ -1,4 +1,76 @@
 package at.aau.hexabrawl.websocketserver.model
 
+import org.springframework.stereotype.Service
+
+/**
+ * Berechnet Hex-Connectivity zwischen den Feldern eines Spielers und seiner BASE.
+ *
+ * Felder, die per Hex-Nachbarschaft nicht mehr mit der BASE verbunden sind,
+ * werden zu SKELETON-Feldern. Einheiten darauf (ausser BASE und SKELETON)
+ * werden zu UnitType.SKELETON.
+ *
+ * Spieler ohne BASE-Unit werden uebersprungen — der WinCondition-Check
+ * kuemmert sich um deren Ausscheiden.
+ */
+@Service
 class ConnectivityService {
+
+    companion object {
+        /** Liefert die 6 Nachbarfelder eines Hex-Feldes in "odd-q offset" Koordinaten. */
+        fun hexNeighbors(x: Int, y: Int): List<Pair<Int, Int>> =
+            if (x % 2 == 0)
+                listOf(x - 1 to y - 1, x - 1 to y, x to y - 1, x to y + 1, x + 1 to y - 1, x + 1 to y)
+            else
+                listOf(x - 1 to y, x - 1 to y + 1, x to y - 1, x to y + 1, x + 1 to y, x + 1 to y + 1)
+    }
+
+    /**
+     * Prueft fuer alle Spieler, ob ihre Felder noch ueber Hex-Nachbarn mit ihrer
+     * BASE verbunden sind. Markiert isolierte Felder als SKELETON.
+     */
+    fun recomputeConnectivity(state: GameState) {
+        state.players.forEach { player ->
+            val baseUnit = state.units.firstOrNull {
+                it.player == player.name && it.type == UnitType.BASE
+            } ?: return@forEach
+
+            val connected = bfsConnectedFields(state, player.name, baseUnit.x, baseUnit.y)
+
+            state.fields.filter { it.owner == player.name && !it.isSkeleton }.forEach { field ->
+                if ((field.x to field.y) !in connected) {
+                    field.isSkeleton = true
+                    state.units.filter {
+                        it.x == field.x && it.y == field.y &&
+                                it.player == player.name &&
+                                it.type != UnitType.BASE &&
+                                it.type != UnitType.SKELETON
+                    }.forEach { it.type = UnitType.SKELETON }
+                }
+            }
+        }
+    }
+
+    private fun bfsConnectedFields(
+        state: GameState,
+        playerName: String,
+        startX: Int,
+        startY: Int
+    ): Set<Pair<Int, Int>> {
+        val visited = mutableSetOf(startX to startY)
+        val queue = ArrayDeque<Pair<Int, Int>>()
+        queue.add(startX to startY)
+
+        while (queue.isNotEmpty()) {
+            val (x, y) = queue.removeFirst()
+            for ((nx, ny) in hexNeighbors(x, y)) {
+                if ((nx to ny) in visited) continue
+                val field = state.fields.firstOrNull { it.x == nx && it.y == ny } ?: continue
+                if (field.owner != playerName) continue
+                if (field.isSkeleton) continue
+                visited.add(nx to ny)
+                queue.add(nx to ny)
+            }
+        }
+        return visited
+    }
 }

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/ConnectivityService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/ConnectivityService.kt
@@ -1,0 +1,4 @@
+package at.aau.hexabrawl.websocketserver.model
+
+class ConnectivityService {
+}

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service
 
 @Service
 class GameService(
-    private val combatService: CombatService
+    private val combatService: CombatService, private val connectivityService: ConnectivityService
 ) {
 
     val gameState = GameState()
@@ -49,11 +49,7 @@ class GameService(
         )
 
         // Liefert die 6 Nachbarfelder eines Hex-Feldes in "odd-q offset" Koordinaten.
-        fun hexNeighbors(x: Int, y: Int): List<Pair<Int, Int>> =
-            if (x % 2 == 0)
-                listOf(x - 1 to y - 1, x - 1 to y, x to y - 1, x to y + 1, x + 1 to y - 1, x + 1 to y)
-            else
-                listOf(x - 1 to y, x - 1 to y + 1, x to y - 1, x to y + 1, x + 1 to y, x + 1 to y + 1)
+        fun hexNeighbors(x: Int, y: Int): List<Pair<Int, Int>> = ConnectivityService.hexNeighbors(x, y)
     }
 
     /**
@@ -424,51 +420,7 @@ class GameService(
      * Spieler ohne BASE-Unit werden uebersprungen — checkWinCondition kuemmert
      * sich um deren Ausscheiden.
      */
-    fun recomputeConnectivity(state: GameState) {
-        state.players.forEach { player ->
-            val baseUnit = state.units.firstOrNull {
-                it.player == player.name && it.type == UnitType.BASE
-            } ?: return@forEach
-
-            val connected = bfsConnectedFields(state, player.name, baseUnit.x, baseUnit.y)
-
-            state.fields.filter { it.owner == player.name && !it.isSkeleton }.forEach { field ->
-                if ((field.x to field.y) !in connected) {
-                    field.isSkeleton = true
-                    state.units.filter {
-                        it.x == field.x && it.y == field.y &&
-                            it.player == player.name &&
-                            it.type != UnitType.BASE &&
-                            it.type != UnitType.SKELETON
-                    }.forEach { it.type = UnitType.SKELETON }
-                }
-            }
-        }
-    }
-
-    private fun bfsConnectedFields(
-        state: GameState,
-        playerName: String,
-        startX: Int,
-        startY: Int
-    ): Set<Pair<Int, Int>> {
-        val visited = mutableSetOf(startX to startY)
-        val queue = ArrayDeque<Pair<Int, Int>>()
-        queue.add(startX to startY)
-
-        while (queue.isNotEmpty()) {
-            val (x, y) = queue.removeFirst()
-            for ((nx, ny) in hexNeighbors(x, y)) {
-                if ((nx to ny) in visited) continue
-                val field = state.fields.firstOrNull { it.x == nx && it.y == ny } ?: continue
-                if (field.owner != playerName) continue
-                if (field.isSkeleton) continue
-                visited.add(nx to ny)
-                queue.add(nx to ny)
-            }
-        }
-        return visited
-    }
+    fun recomputeConnectivity(state: GameState) = connectivityService.recomputeConnectivity(state)
 
     // WICHTIG FÜR TEST — nur den aktuellen Stand lesen
     fun getCurrentState(state: GameState): GameState = synchronized(state.lock) {

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/TestServiceFactory.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/TestServiceFactory.kt
@@ -1,0 +1,23 @@
+package at.aau.hexabrawl.websocketserver
+
+import at.aau.hexabrawl.websocketserver.model.CombatService
+import at.aau.hexabrawl.websocketserver.model.GameService
+import at.aau.hexabrawl.websocketserver.model.ConnectivityService
+
+
+/**
+ * Baut einen voll-konfigurierten GameService fuer Unit-Tests.
+ *
+ * Bei jedem Refactoring-Schritt von GameService musst du NUR diese Datei
+ * anpassen — die Tests selbst rufen ueber [createGameService] auf und
+ * bleiben unveraendert.
+ */
+object TestServiceFactory {
+
+    fun createGameService(): GameService {
+        val combatService = CombatService()
+        val connectivityService = ConnectivityService()
+        return GameService(combatService, connectivityService)
+
+    }
+}

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/BuyUnitRoomTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/BuyUnitRoomTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
+import at.aau.hexabrawl.websocketserver.TestServiceFactory
 
 /**
  * Tests fuer den Buy-Unit Room-Endpoint (#132).
@@ -23,7 +24,7 @@ class BuyUnitRoomTest {
 
     @BeforeEach
     fun setup() {
-        gameService = GameService(CombatService())
+        gameService = TestServiceFactory.createGameService()
         roomRegistry = RoomRegistry()
         messagingTemplate = mock(SimpMessagingTemplate::class.java)
         controller = WebSocketBrokerController(gameService, roomRegistry, messagingTemplate)

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/CheatGiftBlockTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/CheatGiftBlockTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
+import at.aau.hexabrawl.websocketserver.TestServiceFactory
 
 /**
  * Tests, dass /move, /end-turn, /buy-farm und /buy-unit blockiert sind
@@ -23,7 +24,7 @@ class CheatGiftBlockTest {
 
     @BeforeEach
     fun setup() {
-        gameService = GameService(CombatService())
+        gameService = TestServiceFactory.createGameService()
         roomRegistry = RoomRegistry()
         messagingTemplate = mock(SimpMessagingTemplate::class.java)
         controller = WebSocketBrokerController(gameService, roomRegistry, messagingTemplate)

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/ClaimCheatGiftRoomTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/ClaimCheatGiftRoomTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
+import at.aau.hexabrawl.websocketserver.TestServiceFactory
 
 /**
  * Tests fuer den Cheat-Geschenk claim-gift Room-Endpoint.
@@ -23,7 +24,7 @@ class ClaimCheatGiftRoomTest {
 
     @BeforeEach
     fun setup() {
-        gameService = GameService(CombatService())
+        gameService = TestServiceFactory.createGameService()
         roomRegistry = RoomRegistry()
         messagingTemplate = mock(SimpMessagingTemplate::class.java)
         controller = WebSocketBrokerController(gameService, roomRegistry, messagingTemplate)

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/LeaveRoomTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/LeaveRoomTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
+import at.aau.hexabrawl.websocketserver.TestServiceFactory
 
 /**
  * Tests fuer den /leave Room-Endpoint.
@@ -24,7 +25,7 @@ class LeaveRoomTest {
 
     @BeforeEach
     fun setup() {
-        gameService = GameService(CombatService())
+        gameService = TestServiceFactory.createGameService()
         roomRegistry = RoomRegistry()
         messagingTemplate = mock(SimpMessagingTemplate::class.java)
         controller = WebSocketBrokerController(gameService, roomRegistry, messagingTemplate)

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/ReconnectRoomTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/ReconnectRoomTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
+import at.aau.hexabrawl.websocketserver.TestServiceFactory
 
 /**
  * Tests fuer den Reconnect Room-Endpoint.
@@ -24,7 +25,7 @@ class ReconnectRoomTest {
 
     @BeforeEach
     fun setup() {
-        gameService = GameService(CombatService())
+        gameService = TestServiceFactory.createGameService()
         roomRegistry = RoomRegistry()
         messagingTemplate = mock(SimpMessagingTemplate::class.java)
         controller = WebSocketBrokerController(gameService, roomRegistry, messagingTemplate)

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/RespondCheatStealRoomTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/RespondCheatStealRoomTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
+import at.aau.hexabrawl.websocketserver.TestServiceFactory
 
 /**
  * Tests fuer den Cheat-Geschenk respond-steal Room-Endpoint.
@@ -24,7 +25,7 @@ class RespondCheatStealRoomTest {
 
     @BeforeEach
     fun setup() {
-        gameService = GameService(CombatService())
+        gameService = TestServiceFactory.createGameService()
         roomRegistry = RoomRegistry()
         messagingTemplate = mock(SimpMessagingTemplate::class.java)
         controller = WebSocketBrokerController(gameService, roomRegistry, messagingTemplate)

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -8,6 +8,8 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.*
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
+import at.aau.hexabrawl.websocketserver.TestServiceFactory
+
 
 class WebSocketBrokerControllerTest {
 
@@ -19,7 +21,7 @@ class WebSocketBrokerControllerTest {
 
     @BeforeEach
     fun setup() {
-        gameService = GameService(CombatService())
+        gameService = TestServiceFactory.createGameService()
         roomRegistry = RoomRegistry()
         messagingTemplate = mock(SimpMessagingTemplate::class.java) // Mock erstellen
         controller = WebSocketBrokerController(gameService, roomRegistry, messagingTemplate)

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectCleanupServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectCleanupServiceTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.*
 import org.springframework.messaging.simp.SimpMessagingTemplate
+import at.aau.hexabrawl.websocketserver.TestServiceFactory
 
 /**
  * Tests fuer den DisconnectCleanupService.
@@ -21,7 +22,7 @@ class DisconnectCleanupServiceTest {
 
     @BeforeEach
     fun setup() {
-        gameService = GameService(CombatService())
+        gameService = TestServiceFactory.createGameService()
         roomRegistry = RoomRegistry()
         messagingTemplate = mock(SimpMessagingTemplate::class.java)
         cleanup = DisconnectCleanupService(gameService, roomRegistry, messagingTemplate)

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerComponentTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerComponentTest.kt
@@ -7,10 +7,11 @@ import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.web.socket.messaging.SessionDisconnectEvent
+import at.aau.hexabrawl.websocketserver.TestServiceFactory
 
 class DisconnectHandlerComponentTest {
 
-    private val gameService = GameService(CombatService())
+    private val gameService = TestServiceFactory.createGameService()
     private val roomRegistry = RoomRegistry()
     private val messagingTemplate = Mockito.mock(SimpMessagingTemplate::class.java)
     private val handler = DisconnectHandler(gameService, roomRegistry, messagingTemplate)

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerTest.kt
@@ -3,6 +3,7 @@ package at.aau.hexabrawl.websocketserver.model
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import at.aau.hexabrawl.websocketserver.TestServiceFactory
 
 class DisconnectHandlerTest {
 
@@ -10,7 +11,7 @@ class DisconnectHandlerTest {
 
     @BeforeEach
     fun setUp() {
-        gameService = GameService(CombatService())
+        gameService = TestServiceFactory.createGameService()
     }
 
     /**

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConnectivityTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConnectivityTest.kt
@@ -3,6 +3,7 @@ package at.aau.hexabrawl.websocketserver.model
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import at.aau.hexabrawl.websocketserver.TestServiceFactory
 
 class FieldConnectivityTest {
 
@@ -10,7 +11,7 @@ class FieldConnectivityTest {
 
     @BeforeEach
     fun setup() {
-        gameService = GameService(CombatService())
+        gameService = TestServiceFactory.createGameService()
     }
 
     private fun stateWithBase(owner: String, baseX: Int, baseY: Int): GameState =

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConquestTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConquestTest.kt
@@ -3,6 +3,8 @@ package at.aau.hexabrawl.websocketserver.model
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import at.aau.hexabrawl.websocketserver.TestServiceFactory
+
 
 class FieldConquestTest {
 
@@ -10,7 +12,7 @@ class FieldConquestTest {
 
     @BeforeEach
     fun setup() {
-        gameService = GameService(CombatService())
+        gameService = TestServiceFactory.createGameService()
         gameService.handleJoin("Alice")
         gameService.handleJoin("Bob")
         // Standard-Combat-Units platzieren (seit Entfernen der Start-Einheiten

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldTest.kt
@@ -3,6 +3,8 @@ package at.aau.hexabrawl.websocketserver.model
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import at.aau.hexabrawl.websocketserver.TestServiceFactory
+
 
 class FieldTest {
 
@@ -10,7 +12,7 @@ class FieldTest {
 
     @BeforeEach
     fun setup() {
-        gameService = GameService(CombatService())
+        gameService = TestServiceFactory.createGameService()
     }
 
     @Test

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/GameModelTest.kt
@@ -2,6 +2,7 @@ package at.aau.hexabrawl.websocketserver.model
 
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import at.aau.hexabrawl.websocketserver.TestServiceFactory
 
 class GameModelTest {
 
@@ -92,7 +93,7 @@ class GameModelTest {
     @Test
     fun `handleJoin only modifies provided state`() {
 
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
 
         val state1 = GameState()
         val state2 = GameState()
@@ -115,7 +116,7 @@ class GameModelTest {
     @Test
     fun `legacy handleJoin bridge still uses gameState`() {
 
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
 
         gameService.handleJoin(
             "Josef",
@@ -135,7 +136,7 @@ class GameModelTest {
 
     @Test
     fun `handleMove only modifies provided state`() {
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
 
         val state1 = GameState()
         val state2 = GameState()
@@ -170,7 +171,7 @@ class GameModelTest {
 
     @Test
     fun `legacy handleMove bridge still uses gameState`() {
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
 
         gameService.handleJoin("Josef", "s1")
         gameService.handleJoin("Marie", "s2")
@@ -200,7 +201,7 @@ class GameModelTest {
 
     @Test
     fun `handleDisconnect only modifies provided state`() {
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
         val state1 = GameState()
         val state2 = GameState()
 
@@ -217,7 +218,7 @@ class GameModelTest {
 
     @Test
     fun `legacy handleDisconnect bridge still uses gameState`() {
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
 
         gameService.handleJoin("Josef", "s1")
         gameService.handleDisconnect("s1")
@@ -230,7 +231,7 @@ class GameModelTest {
     @Test
     fun `initializeGame only modifies provided state`() {
 
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
 
         val state1 = GameState()
         val state2 = GameState()
@@ -249,7 +250,7 @@ class GameModelTest {
     @Test
     fun `resetToStartCondition only modifies provided state`() {
 
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
 
         val state1 = GameState()
         val state2 = GameState()
@@ -273,7 +274,7 @@ class GameModelTest {
     @Test
     fun `getCurrentState returns provided state`() {
 
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
 
         val state1 = GameState()
 
@@ -285,7 +286,7 @@ class GameModelTest {
 
     @Test
     fun `triad outpost does not start after second player joins`() {
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
         val roomRegistry = RoomRegistry()
 
         val room = roomRegistry.createRoom(
@@ -315,7 +316,7 @@ class GameModelTest {
     @Test
     fun `triad outpost starts when third player joins`() {
 
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
         val roomRegistry = RoomRegistry()
 
         val room = roomRegistry.createRoom(
@@ -355,7 +356,7 @@ class GameModelTest {
     @Test
     fun `battlefield peaks does not start after third player joins`() {
 
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
         val roomRegistry = RoomRegistry()
 
         val room = roomRegistry.createRoom(
@@ -389,7 +390,7 @@ class GameModelTest {
     @Test
     fun `battlefield peaks starts when fourth player joins`() {
 
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
         val roomRegistry = RoomRegistry()
 
         val room = roomRegistry.createRoom(
@@ -435,7 +436,7 @@ class GameModelTest {
     fun `triad outpost turn stays after only one move`() {
 
         val roomRegistry = RoomRegistry()
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
 
         val room = roomRegistry.createRoom(GameMode.TRIAD_OUTPOST)
 
@@ -466,7 +467,7 @@ class GameModelTest {
     fun `battlefield peaks turn stays after only one move`() {
 
         val roomRegistry = RoomRegistry()
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
 
         val room = roomRegistry.createRoom(GameMode.BATTLEFIELD_PEAKS)
 
@@ -498,7 +499,7 @@ class GameModelTest {
     fun `triad outpost switches turn after all three units moved`() {
 
         val roomRegistry = RoomRegistry()
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
 
         val room = roomRegistry.createRoom(GameMode.TRIAD_OUTPOST)
 
@@ -537,7 +538,7 @@ class GameModelTest {
     fun `triad outpost endTurn forces switch with units remaining`() {
 
         val roomRegistry = RoomRegistry()
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
 
         val room = roomRegistry.createRoom(GameMode.TRIAD_OUTPOST)
 
@@ -562,7 +563,7 @@ class GameModelTest {
     fun `battlefield peaks switches turn after all three units moved`() {
 
         val roomRegistry = RoomRegistry()
-        val gameService = GameService(CombatService())
+        val gameService = TestServiceFactory.createGameService()
 
         val room = roomRegistry.createRoom(GameMode.BATTLEFIELD_PEAKS)
 

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/UnitTypeTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/UnitTypeTest.kt
@@ -3,6 +3,8 @@ package at.aau.hexabrawl.websocketserver.model
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.BeforeEach
+import at.aau.hexabrawl.websocketserver.TestServiceFactory
+
 
 class UnitTypeTest {
 
@@ -11,7 +13,7 @@ class UnitTypeTest {
 
     @BeforeEach
     fun setup() {
-        gameService = GameService(CombatService())
+        gameService = TestServiceFactory.createGameService()
         gameState = gameService.gameState
 
         val state = gameService.gameState

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import at.aau.hexabrawl.websocketserver.TestServiceFactory
 
 class GameServiceTest {
 
@@ -15,7 +16,7 @@ class GameServiceTest {
 
     @BeforeEach
     fun setup() {
-        gameService = GameService(CombatService())
+        gameService = TestServiceFactory.createGameService()
     }
 
     /**
@@ -587,7 +588,7 @@ class GameServiceTest {
 
     @Test
     fun `field income added on top of farm income`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             // Spiel starten und Alice an die Reihe setzen
             status = GameStatus.IN_PROGRESS
@@ -611,7 +612,7 @@ class GameServiceTest {
 
     @Test
     fun `field income works with zero farms`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             // Spiel starten und Alice an die Reihe setzen
             status = GameStatus.IN_PROGRESS
@@ -629,7 +630,7 @@ class GameServiceTest {
 
     @Test
     fun `field income works with zero fields and zero farms`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             status = GameStatus.IN_PROGRESS
             currentTurn = "Alice"
@@ -645,7 +646,7 @@ class GameServiceTest {
 
     @Test
     fun `field income excludes skeleton fields`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             status = GameStatus.IN_PROGRESS
             currentTurn = "Alice"
@@ -665,7 +666,7 @@ class GameServiceTest {
 
     @Test
     fun `field income is zero when all fields are skeleton`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             status = GameStatus.IN_PROGRESS
             currentTurn = "Alice"
@@ -682,7 +683,7 @@ class GameServiceTest {
 
     @Test
     fun `recomputePlayerStats income drops when a field becomes skeleton`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             players.add(Player(name = "Alice", farms = 0))
             fields.add(Field(0, 0, owner = "Alice"))
@@ -704,7 +705,7 @@ class GameServiceTest {
 
     @Test
     fun `recomputePlayerStats sets income from fields and farms`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             players.add(Player(name = "Alice", farms = 2))
             fields.addAll(List(4) { Field(0, it, owner = "Alice") })
@@ -717,7 +718,7 @@ class GameServiceTest {
 
     @Test
     fun `recomputePlayerStats sets upkeep based on living non-base units`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             players.add(Player(name = "Alice"))
             units.addAll(listOf(
@@ -735,7 +736,7 @@ class GameServiceTest {
 
     @Test
     fun `after buyFarm the broadcasted state contains updated income`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             players.add(Player(name = "Alice", gold = 10, farms = 0))
         }
@@ -752,7 +753,7 @@ class GameServiceTest {
 
     @Test
     fun `after field conquest income shifts from old to new owner`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             players.add(Player(name = "Alice"))
             players.add(Player(name = "Bob"))
@@ -772,7 +773,7 @@ class GameServiceTest {
 
     @Test
     fun `after endTurn with insolvency upkeep drops to zero`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             status = GameStatus.IN_PROGRESS
 
@@ -801,7 +802,7 @@ class GameServiceTest {
 
     @Test
     fun `endTurn applies economy only to the ending player`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             players.addAll(listOf(
                 Player(name = "Alice", gold = 0, farms = 1),
@@ -819,7 +820,7 @@ class GameServiceTest {
 
     @Test
     fun `each player gets exactly one income per full round in TRIAD_OUTPOST`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             gameMode = GameMode.TRIAD_OUTPOST
             players.addAll(listOf(
@@ -841,7 +842,7 @@ class GameServiceTest {
 
     @Test
     fun `insolvency only affects the ending player`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             players.addAll(listOf(
                 Player(name = "Alice", gold = 0, farms = 0),
@@ -864,7 +865,7 @@ class GameServiceTest {
 
     @Test
     fun `each player gets exactly one income per full round in BATTLEFIELD_PEAKS`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             gameMode = GameMode.BATTLEFIELD_PEAKS
             players.addAll(listOf(
@@ -889,7 +890,7 @@ class GameServiceTest {
 
     @Test
     fun `disconnect removes player but game continues cleanly`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             gameMode = GameMode.TRIAD_OUTPOST
             players.addAll(listOf(
@@ -918,7 +919,7 @@ class GameServiceTest {
 
     @Test
     fun `claimCheatGift adds positive delta and sets pendingGift`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             players.addAll(listOf(
                 Player(name = "Alice", gold = 5),
@@ -940,7 +941,7 @@ class GameServiceTest {
 
     @Test
     fun `claimCheatGift caps gold at zero on negative delta`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             players.addAll(listOf(
                 Player(name = "Alice", gold = 3),
@@ -955,7 +956,7 @@ class GameServiceTest {
 
     @Test
     fun `claimCheatGift does not cap when negative delta fits`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             players.addAll(listOf(
                 Player(name = "Alice", gold = 5),
@@ -970,7 +971,7 @@ class GameServiceTest {
 
     @Test
     fun `claimCheatGift sets pendingDecisions to player count minus one`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             players.addAll(listOf(
                 Player(name = "Alice", gold = 0),
@@ -987,7 +988,7 @@ class GameServiceTest {
 
     @Test
     fun `respondCheatSteal accept transfers delta and clears pendingGift`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             players.addAll(listOf(
                 Player(name = "Alice", gold = 12, hasUsedGift = true),
@@ -1005,7 +1006,7 @@ class GameServiceTest {
 
     @Test
     fun `respondCheatSteal accept caps stealer gold at zero on negative delta`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             players.addAll(listOf(
                 Player(name = "Alice", gold = 0, hasUsedGift = true),
@@ -1023,7 +1024,7 @@ class GameServiceTest {
 
     @Test
     fun `respondCheatSteal decline decrements pendingDecisions when others remain`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             players.addAll(listOf(
                 Player(name = "Alice", gold = 10, hasUsedGift = true),
@@ -1042,7 +1043,7 @@ class GameServiceTest {
 
     @Test
     fun `respondCheatSteal decline clears pendingGift when last decision`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             players.addAll(listOf(
                 Player(name = "Alice", gold = 10, hasUsedGift = true),
@@ -1059,7 +1060,7 @@ class GameServiceTest {
 
     @Test
     fun `hardDelete clears pendingGift when owner disconnects`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             gameMode = GameMode.TRIAD_OUTPOST
             status = GameStatus.IN_PROGRESS
@@ -1085,7 +1086,7 @@ class GameServiceTest {
 
     @Test
     fun `hardDelete decrements pendingDecisions when stealer disconnects`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             gameMode = GameMode.TRIAD_OUTPOST
             status = GameStatus.IN_PROGRESS
@@ -1112,7 +1113,7 @@ class GameServiceTest {
 
     @Test
     fun `hardDelete clears pendingGift when last stealer disconnects`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             gameMode = GameMode.TRIAD_OUTPOST
             status = GameStatus.IN_PROGRESS
@@ -1136,7 +1137,7 @@ class GameServiceTest {
 
     @Test
     fun `base loss in multiplayer eliminates player and frees fields`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             status = GameStatus.IN_PROGRESS
             gameMode = GameMode.TRIAD_OUTPOST
@@ -1179,7 +1180,7 @@ class GameServiceTest {
 
     @Test
     fun `disconnect of active player passes turn and eliminates player`() {
-        val service = GameService(CombatService())
+        val service = TestServiceFactory.createGameService()
         val state = GameState().apply {
             status = GameStatus.IN_PROGRESS
             gameMode = GameMode.TRIAD_OUTPOST


### PR DESCRIPTION
**Problem / Kontext**
Dieser PR ist der erste Schritt (Sub-Issue #208) des großen `GameService` Refactorings (Parent #207). Die `GameService` "God-Class" wird in dedizierte Services aufgespalten. Die Isolierung der Hex-Konnektivitäts-Logik macht hier den Anfang, da sie am wenigsten Verzahnung mit dem restlichen State hat.

Zusätzlich musste die Test-Infrastruktur umgebaut werden, damit die kommenden 5 Refactoring-Schritte nicht jedes Mal alle Test-Dateien brechen, wenn der `GameService`-Constructor erweitert wird.

**Lösung / Umsetzung**
* **`ConnectivityService`:** Neue `@Service`-Bean erstellt. Die Methoden `recomputeConnectivity`, `bfsConnectedFields` und `hexNeighbors` (Companion) wurden dorthin ausgelagert.
* **`GameService` Bridges:** `recomputeConnectivity` und `hexNeighbors` bleiben als Bridge-Methoden im `GameService` erhalten. Dadurch bleiben die Public-API, Controller und Tests komplett kompatibel und das Verhalten ändert sich nicht.
* **`TestServiceFactory`:** Eine zentrale Factory-Klasse wurde angelegt. Alle betroffenen Unit-Test-Klassen (16 Stück) greifen nun über `TestServiceFactory.createGameService()` auf den Service zu. Zukünftige Constructor-Erweiterungen müssen nur noch an dieser einen Stelle gepflegt werden.

**Testing**
* Lokaler Maven-Build (`./mvnw test -DskipITs`) läuft fehlerfrei durch.
* Alle 354 Unit-Tests sind grün.
* Keine Verhaltensänderung für den Endnutzer.

Closes #208