### PR TITLE
Refactor #209: EconomyService extrahieren (Wirtschafts-Logik)

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomController.kt
@@ -2,7 +2,7 @@ package at.aau.hexabrawl.websocketserver.controller
 
 import at.aau.hexabrawl.websocketserver.model.GameMode
 import at.aau.hexabrawl.websocketserver.model.RoomRegistry
-import at.aau.hexabrawl.websocketserver.model.RoomCleanupService
+import at.aau.hexabrawl.websocketserver.service.RoomCleanupService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerController.kt
@@ -5,7 +5,7 @@ import at.aau.hexabrawl.websocketserver.model.ClaimGiftRequest
 import at.aau.hexabrawl.websocketserver.model.EndTurnRequest
 import at.aau.hexabrawl.websocketserver.model.ErrorCode
 import at.aau.hexabrawl.websocketserver.model.ErrorMessage
-import at.aau.hexabrawl.websocketserver.model.GameService
+import at.aau.hexabrawl.websocketserver.service.GameService
 import at.aau.hexabrawl.websocketserver.model.GameState
 import at.aau.hexabrawl.websocketserver.model.GameStatus
 import at.aau.hexabrawl.websocketserver.model.JoinRequest

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandler.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandler.kt
@@ -1,5 +1,6 @@
 package at.aau.hexabrawl.websocketserver.model
 
+import at.aau.hexabrawl.websocketserver.service.GameService
 import org.springframework.context.event.EventListener
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -1,6 +1,7 @@
 package at.aau.hexabrawl.websocketserver.model
 
 import at.aau.hexabrawl.websocketserver.service.CombatService
+import at.aau.hexabrawl.websocketserver.service.ConnectivityService
 import org.springframework.stereotype.Service
 
 @Service

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/GameService.kt
@@ -1,5 +1,6 @@
 package at.aau.hexabrawl.websocketserver.model
 
+import at.aau.hexabrawl.websocketserver.service.CombatService
 import org.springframework.stereotype.Service
 
 @Service

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/JoinRequest.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/model/JoinRequest.kt
@@ -10,7 +10,7 @@ package at.aau.hexabrawl.websocketserver.model
  *
  * Das Farbfeld ist nullable, damit Clients (und Tests) auch joinen
  * koennen, ohne eine Farbe vorzugeben. In diesem Fall vergibt
- * [at.aau.hexabrawl.websocketserver.model.GameService.handleJoin] die
+ * [at.aau.hexabrawl.websocketserver.service.GameService.handleJoin] die
  * Farbe dynamisch anhand der Spielerposition.
  */
 data class JoinRequest(

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/CombatService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/CombatService.kt
@@ -1,5 +1,8 @@
-package at.aau.hexabrawl.websocketserver.model
+package at.aau.hexabrawl.websocketserver.service
 
+import at.aau.hexabrawl.websocketserver.model.CombatResult
+import at.aau.hexabrawl.websocketserver.model.GameUnit
+import at.aau.hexabrawl.websocketserver.model.UnitType
 import org.springframework.stereotype.Service
 
 @Service

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/ConnectivityService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/ConnectivityService.kt
@@ -1,5 +1,7 @@
-package at.aau.hexabrawl.websocketserver.model
+package at.aau.hexabrawl.websocketserver.service
 
+import at.aau.hexabrawl.websocketserver.model.GameState
+import at.aau.hexabrawl.websocketserver.model.UnitType
 import org.springframework.stereotype.Service
 
 /**

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/DisconnectCleanupService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/DisconnectCleanupService.kt
@@ -1,5 +1,7 @@
-package at.aau.hexabrawl.websocketserver.model
+package at.aau.hexabrawl.websocketserver.service
 
+import at.aau.hexabrawl.websocketserver.model.GameService
+import at.aau.hexabrawl.websocketserver.model.RoomRegistry
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -7,7 +9,7 @@ import org.springframework.stereotype.Component
 /**
  * Scheduled Cleanup-Task fuer den Reconnect-Flow.
  *
- * Laeuft alle 5 Sekunden ueber alle Rooms und ruft [GameService.hardDelete]
+ * Laeuft alle 5 Sekunden ueber alle Rooms und ruft [at.aau.hexabrawl.websocketserver.model.GameService.hardDelete]
  * fuer Spieler auf, deren Soft-Disconnect laenger als [GRACE_PERIOD_MS] zurueckliegt.
  *
  * Nach dem Cleanup wird der aktuelle GameState an die Room-Subscriber gebroadcastet.

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/DisconnectCleanupService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/DisconnectCleanupService.kt
@@ -1,6 +1,6 @@
 package at.aau.hexabrawl.websocketserver.service
 
-import at.aau.hexabrawl.websocketserver.model.GameService
+import at.aau.hexabrawl.websocketserver.service.GameService
 import at.aau.hexabrawl.websocketserver.model.RoomRegistry
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.scheduling.annotation.Scheduled
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component
 /**
  * Scheduled Cleanup-Task fuer den Reconnect-Flow.
  *
- * Laeuft alle 5 Sekunden ueber alle Rooms und ruft [at.aau.hexabrawl.websocketserver.model.GameService.hardDelete]
+ * Laeuft alle 5 Sekunden ueber alle Rooms und ruft [GameService.hardDelete]
  * fuer Spieler auf, deren Soft-Disconnect laenger als [GRACE_PERIOD_MS] zurueckliegt.
  *
  * Nach dem Cleanup wird der aktuelle GameState an die Room-Subscriber gebroadcastet.

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/EconomyService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/EconomyService.kt
@@ -1,0 +1,97 @@
+package at.aau.hexabrawl.websocketserver.model
+
+import org.springframework.stereotype.Service
+
+/**
+ * Wirtschafts-Logik des Spiels: Income- und Upkeep-Berechnung, Buy-Unit,
+ * Per-Player-Economy-Tick beim Turn-Ende.
+ *
+ * Income setzt sich zusammen aus Feld-Anteil (1 Gold pro eigenem,
+ * nicht-skeletonisiertem Feld) + Farm-Anteil (3 Gold pro Farm).
+ *
+ * Upkeep ist progressiv: 1. Einheit = 3, 2. = 4, 3. = 5, usw.
+ */
+@Service
+class EconomyService {
+
+    companion object {
+        const val STARTING_GOLD = 6
+        const val FARM_INCOME_PER_ROUND = 3
+        const val FIELD_INCOME_PER_ROUND = 1
+        const val FARM_BASE_COST = 10
+        const val FARM_COST_INCREMENT = 1
+        const val UNIT_PRICE = 5
+    }
+
+    fun computeIncome(player: Player, state: GameState): Int {
+        val ownedFields = state.fields.count { it.owner == player.name && !it.isSkeleton }
+        return ownedFields * FIELD_INCOME_PER_ROUND + player.farms * FARM_INCOME_PER_ROUND
+    }
+
+    fun computeUpkeep(player: Player, state: GameState): Int {
+        val unitCount = state.units.count {
+            it.player == player.name && it.type != UnitType.SKELETON && it.type != UnitType.BASE
+        }
+        return (0 until unitCount).sumOf { 3 + it }
+    }
+
+    fun recomputePlayerStats(state: GameState) {
+        state.players.forEach { player ->
+            player.income = computeIncome(player, state)
+            player.upkeep = computeUpkeep(player, state)
+        }
+    }
+
+    /**
+     * Wirtschafts-Rundenabschluss fuer einen Spieler.
+     * Farm- + Feld-Einkommen gutschreiben, Unterhalt abziehen.
+     * Bei Insolvenz: Gold auf 0, alle lebenden Truppen → SKELETON.
+     */
+    fun applyEconomy(state: GameState, player: Player) {
+        player.gold += computeIncome(player, state)
+        val upkeep = computeUpkeep(player, state)
+        val playerUnits = state.units.filter {
+            it.player == player.name && it.type != UnitType.SKELETON && it.type != UnitType.BASE
+        }
+
+        if (player.gold >= upkeep) {
+            player.gold -= upkeep
+        } else {
+            player.gold = 0
+            playerUnits.forEach { it.type = UnitType.SKELETON }
+        }
+    }
+
+    /**
+     * Kauft eine neue Einheit und platziert sie an (x, y).
+     * Setzt voraus, dass der Controller bereits alle Validierungen
+     * durchgefuehrt hat.
+     */
+    fun buyUnit(
+        state: GameState,
+        playerName: String,
+        type: UnitType,
+        x: Int,
+        y: Int
+    ): GameState = synchronized(state.lock) {
+        val player = state.players.find { it.name == playerName } ?: return state
+
+        state.units.removeIf {
+            it.x == x && it.y == y && it.type == UnitType.SKELETON
+        }
+
+        player.gold -= UNIT_PRICE
+
+        state.units.add(
+            GameUnit(
+                player = playerName,
+                x = x,
+                y = y,
+                type = type,
+                hasMovedThisTurn = true
+            )
+        )
+
+        return state
+    }
+}

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/GameService.kt
@@ -1,7 +1,16 @@
-package at.aau.hexabrawl.websocketserver.model
+package at.aau.hexabrawl.websocketserver.service
 
-import at.aau.hexabrawl.websocketserver.service.CombatService
-import at.aau.hexabrawl.websocketserver.service.ConnectivityService
+import at.aau.hexabrawl.websocketserver.model.Field
+import at.aau.hexabrawl.websocketserver.model.GameMode
+import at.aau.hexabrawl.websocketserver.model.GameState
+import at.aau.hexabrawl.websocketserver.model.GameStatus
+import at.aau.hexabrawl.websocketserver.model.GameUnit
+import at.aau.hexabrawl.websocketserver.model.HexDistance
+import at.aau.hexabrawl.websocketserver.model.Move
+import at.aau.hexabrawl.websocketserver.model.PendingGift
+import at.aau.hexabrawl.websocketserver.model.Player
+import at.aau.hexabrawl.websocketserver.model.PlayerColor
+import at.aau.hexabrawl.websocketserver.model.UnitType
 import org.springframework.stereotype.Service
 
 @Service

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/GameService.kt
@@ -1,5 +1,6 @@
 package at.aau.hexabrawl.websocketserver.service
 
+import at.aau.hexabrawl.websocketserver.model.EconomyService
 import at.aau.hexabrawl.websocketserver.model.Field
 import at.aau.hexabrawl.websocketserver.model.GameMode
 import at.aau.hexabrawl.websocketserver.model.GameState
@@ -15,7 +16,7 @@ import org.springframework.stereotype.Service
 
 @Service
 class GameService(
-    private val combatService: CombatService, private val connectivityService: ConnectivityService
+    private val combatService: CombatService, private val connectivityService: ConnectivityService, private val economyService: EconomyService
 ) {
 
     val gameState = GameState()
@@ -28,12 +29,13 @@ class GameService(
         // Maximale Hex-Distanz, die eine Einheit pro Zug zuruecklegen darf.
         const val MAX_MOVE_DISTANCE = 2
 
-        // Wirtschaftssystem (#60)
-        const val STARTING_GOLD = 6
-        const val FARM_INCOME_PER_ROUND = 3
-        const val FIELD_INCOME_PER_ROUND = 1
-        const val FARM_BASE_COST = 10
-        const val FARM_COST_INCREMENT = 1
+        // Wirtschaftssystem (#60) — Bridges zu EconomyService fuer Controller + Tests
+        const val STARTING_GOLD = EconomyService.STARTING_GOLD
+        const val FARM_INCOME_PER_ROUND = EconomyService.FARM_INCOME_PER_ROUND
+        const val FIELD_INCOME_PER_ROUND = EconomyService.FIELD_INCOME_PER_ROUND
+        const val FARM_BASE_COST = EconomyService.FARM_BASE_COST
+        const val FARM_COST_INCREMENT = EconomyService.FARM_COST_INCREMENT
+
 
         // Board-Dimensionen pro Modus.
         const val DUAL_VALLEY_BOARD_ROWS = 9
@@ -43,9 +45,8 @@ class GameService(
         const val BATTLEFIELD_BOARD_ROWS = 13
         const val BATTLEFIELD_BOARD_COLS = 13
 
-        // Preis fuer eine gekaufte Einheit (#132).
-        // Synchron mit BottomHudLogic.priceOf in der App halten.
-        const val UNIT_PRICE = 5
+        // Bridge zu EconomyService.UNIT_PRICE
+        const val UNIT_PRICE = EconomyService.UNIT_PRICE
 
         // Basis-Positionen fuer DUAL_VALLEY (#104).
         val BASE_POSITION_P1: Pair<Int, Int> = Pair(2, 2)
@@ -360,7 +361,7 @@ class GameService(
 
         // Wirtschaft des Spielers, dessen Zug gerade endet
         state.players.firstOrNull { it.name == state.currentTurn }?.let {
-            applyEconomy(state, it)
+            economyService.applyEconomy(state, it)
         }
 
         if (state.players.size == 2) {
@@ -546,93 +547,17 @@ class GameService(
 
     fun handleDisconnect(sessionId: String): GameState = handleDisconnect(this.gameState, sessionId)
 
-    /**
-     * Wirtschafts-Rundenabschluss (#60).
-     * Farm-Einkommen gutschreiben, Unterhalt abziehen (1. Einheit 3 Gold, jede weitere +1).
-     * Bei Insolvenz: Gold auf 0, alle lebenden Truppen → SKELETON.
-     */
-    private fun applyEconomy(state: GameState, player: Player) {
-        player.gold += computeIncome(player, state)
-        val upkeep = computeUpkeep(player, state)
-        val playerUnits = state.units.filter {
-            it.player == player.name && it.type != UnitType.SKELETON && it.type != UnitType.BASE
-        }
-
-        if (player.gold >= upkeep) {
-            player.gold -= upkeep
-        } else {
-            player.gold = 0
-            playerUnits.forEach { it.type = UnitType.SKELETON }
-        }
-    }
-
-    /**
-     * Kauft eine neue Einheit und platziert sie an (x, y) (#132).
-     *
-     * Diese Methode setzt voraus, dass der Controller bereits alle
-     * Validierungen durchgefuehrt hat (Spieler am Zug, Type gueltig,
-     * Feld gehoert dem Spieler, Feld nicht besetzt, genug Gold).
-     *
-     * Verhalten:
-     *  - Falls ein Skelett auf dem Zielfeld steht, wird es entfernt
-     *    (analog zum Move-Verhalten aus #104). Konsistent mit der
-     *    Annahme, dass ein eigenes Feld zum eigenen Territorium gehoert
-     *    und damit mit der Basis verbunden ist.
-     *  - Gold wird abgezogen.
-     *  - Neue Einheit wird mit hasMovedThisTurn = true hinzugefuegt —
-     *    eine im selben Zug gekaufte Einheit darf nicht zusaetzlich
-     *    noch ziehen.
-     *
-     * Thread-safe ueber state.lock.
-     */
+    /** Bridge zu EconomyService.buyUnit. */
     fun buyUnit(
         state: GameState,
         playerName: String,
         type: UnitType,
         x: Int,
         y: Int
-    ): GameState = synchronized(state.lock) {
-        val player = state.players.find { it.name == playerName } ?: return state
+    ): GameState = economyService.buyUnit(state, playerName, type, x, y)
 
-        // Skelett auf dem Zielfeld entfernen, falls vorhanden
-        state.units.removeIf {
-            it.x == x && it.y == y && it.type == UnitType.SKELETON
-        }
-
-        // Gold abziehen
-        player.gold -= UNIT_PRICE
-
-        // Neue Einheit mit hasMovedThisTurn = true
-        state.units.add(
-            GameUnit(
-                player = playerName,
-                x = x,
-                y = y,
-                type = type,
-                hasMovedThisTurn = true
-            )
-        )
-
-        return state
-    }
-    private fun computeIncome(player: Player, state: GameState): Int {
-        val ownedFields = state.fields.count { it.owner == player.name && !it.isSkeleton }
-        return ownedFields * FIELD_INCOME_PER_ROUND + player.farms * FARM_INCOME_PER_ROUND
-    }
-
-    private fun computeUpkeep(player: Player, state: GameState): Int {
-        val unitCount = state.units.count {
-            it.player == player.name && it.type != UnitType.SKELETON && it.type != UnitType.BASE
-        }
-        return (0 until unitCount).sumOf { 3 + it }
-    }
-
-    fun recomputePlayerStats(state: GameState) {
-        state.players.forEach { player ->
-            player.income = computeIncome(player, state)
-            player.upkeep = computeUpkeep(player, state)
-        }
-    }
+    /** Bridge zu EconomyService — Controller + Tests rufen das auf. */
+    fun recomputePlayerStats(state: GameState) = economyService.recomputePlayerStats(state)
 
     /**
      * Schummel-Geschenk oeffnen (Cheat-Gift).

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/RoomCleanupService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/RoomCleanupService.kt
@@ -1,5 +1,7 @@
-package at.aau.hexabrawl.websocketserver.model
+package at.aau.hexabrawl.websocketserver.service
 
+import at.aau.hexabrawl.websocketserver.model.GameStatus
+import at.aau.hexabrawl.websocketserver.model.RoomRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.scheduling.annotation.Scheduled

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/websocket/test/TestController.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/websocket/test/TestController.kt
@@ -1,6 +1,6 @@
 package at.aau.hexabrawl.websocketserver.websocket.test
 
-import at.aau.hexabrawl.websocketserver.model.GameService
+import at.aau.hexabrawl.websocketserver.service.GameService
 import at.aau.hexabrawl.websocketserver.model.GameState
 import at.aau.hexabrawl.websocketserver.model.Move
 import org.springframework.messaging.simp.SimpMessagingTemplate

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/TestServiceFactory.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/TestServiceFactory.kt
@@ -2,7 +2,7 @@ package at.aau.hexabrawl.websocketserver
 
 import at.aau.hexabrawl.websocketserver.service.CombatService
 import at.aau.hexabrawl.websocketserver.model.GameService
-import at.aau.hexabrawl.websocketserver.model.ConnectivityService
+import at.aau.hexabrawl.websocketserver.service.ConnectivityService
 
 
 /**

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/TestServiceFactory.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/TestServiceFactory.kt
@@ -1,6 +1,6 @@
 package at.aau.hexabrawl.websocketserver
 
-import at.aau.hexabrawl.websocketserver.model.CombatService
+import at.aau.hexabrawl.websocketserver.service.CombatService
 import at.aau.hexabrawl.websocketserver.model.GameService
 import at.aau.hexabrawl.websocketserver.model.ConnectivityService
 

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/TestServiceFactory.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/TestServiceFactory.kt
@@ -1,7 +1,7 @@
 package at.aau.hexabrawl.websocketserver
 
 import at.aau.hexabrawl.websocketserver.service.CombatService
-import at.aau.hexabrawl.websocketserver.model.GameService
+import at.aau.hexabrawl.websocketserver.service.GameService
 import at.aau.hexabrawl.websocketserver.service.ConnectivityService
 
 

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/TestServiceFactory.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/TestServiceFactory.kt
@@ -1,5 +1,6 @@
 package at.aau.hexabrawl.websocketserver
 
+import at.aau.hexabrawl.websocketserver.model.EconomyService
 import at.aau.hexabrawl.websocketserver.service.CombatService
 import at.aau.hexabrawl.websocketserver.service.GameService
 import at.aau.hexabrawl.websocketserver.service.ConnectivityService
@@ -17,7 +18,8 @@ object TestServiceFactory {
     fun createGameService(): GameService {
         val combatService = CombatService()
         val connectivityService = ConnectivityService()
-        return GameService(combatService, connectivityService)
+        val economyService = EconomyService()
+        return GameService(combatService, connectivityService, economyService)
 
     }
 }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/BuyUnitRoomTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/BuyUnitRoomTest.kt
@@ -8,6 +8,7 @@ import org.mockito.Mockito.*
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import at.aau.hexabrawl.websocketserver.TestServiceFactory
+import at.aau.hexabrawl.websocketserver.service.GameService
 
 /**
  * Tests fuer den Buy-Unit Room-Endpoint (#132).

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/CheatGiftBlockTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/CheatGiftBlockTest.kt
@@ -8,6 +8,7 @@ import org.mockito.Mockito.*
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import at.aau.hexabrawl.websocketserver.TestServiceFactory
+import at.aau.hexabrawl.websocketserver.service.GameService
 
 /**
  * Tests, dass /move, /end-turn, /buy-farm und /buy-unit blockiert sind

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/ClaimCheatGiftRoomTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/ClaimCheatGiftRoomTest.kt
@@ -8,6 +8,7 @@ import org.mockito.Mockito.*
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import at.aau.hexabrawl.websocketserver.TestServiceFactory
+import at.aau.hexabrawl.websocketserver.service.GameService
 
 /**
  * Tests fuer den Cheat-Geschenk claim-gift Room-Endpoint.

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/LeaveRoomTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/LeaveRoomTest.kt
@@ -8,6 +8,7 @@ import org.mockito.Mockito.*
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import at.aau.hexabrawl.websocketserver.TestServiceFactory
+import at.aau.hexabrawl.websocketserver.service.GameService
 
 /**
  * Tests fuer den /leave Room-Endpoint.

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/ReconnectRoomTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/ReconnectRoomTest.kt
@@ -8,6 +8,7 @@ import org.mockito.Mockito.*
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import at.aau.hexabrawl.websocketserver.TestServiceFactory
+import at.aau.hexabrawl.websocketserver.service.GameService
 
 /**
  * Tests fuer den Reconnect Room-Endpoint.

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/RespondCheatStealRoomTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/RespondCheatStealRoomTest.kt
@@ -8,6 +8,7 @@ import org.mockito.Mockito.*
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import at.aau.hexabrawl.websocketserver.TestServiceFactory
+import at.aau.hexabrawl.websocketserver.service.GameService
 
 /**
  * Tests fuer den Cheat-Geschenk respond-steal Room-Endpoint.

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/RoomControllerTest.kt
@@ -2,7 +2,7 @@ package at.aau.hexabrawl.websocketserver.controller
 
 import at.aau.hexabrawl.websocketserver.model.GameMode
 import at.aau.hexabrawl.websocketserver.model.GameStatus
-import at.aau.hexabrawl.websocketserver.model.RoomCleanupService
+import at.aau.hexabrawl.websocketserver.service.RoomCleanupService
 import at.aau.hexabrawl.websocketserver.model.RoomRegistry
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/controller/WebSocketBrokerControllerTest.kt
@@ -9,6 +9,7 @@ import org.mockito.Mockito.*
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import at.aau.hexabrawl.websocketserver.TestServiceFactory
+import at.aau.hexabrawl.websocketserver.service.GameService
 
 
 class WebSocketBrokerControllerTest {

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/integration/MultiRoomIntegrationTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/integration/MultiRoomIntegrationTest.kt
@@ -2,6 +2,7 @@ package at.aau.hexabrawl.websocketserver.integration
 
 import org.junit.jupiter.api.Test
 import at.aau.hexabrawl.websocketserver.model.*
+import at.aau.hexabrawl.websocketserver.service.GameService
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectCleanupServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectCleanupServiceTest.kt
@@ -8,6 +8,7 @@ import org.mockito.Mockito.*
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import at.aau.hexabrawl.websocketserver.TestServiceFactory
 import at.aau.hexabrawl.websocketserver.service.DisconnectCleanupService
+import at.aau.hexabrawl.websocketserver.service.GameService
 
 /**
  * Tests fuer den DisconnectCleanupService.

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectCleanupServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectCleanupServiceTest.kt
@@ -7,6 +7,7 @@ import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.*
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import at.aau.hexabrawl.websocketserver.TestServiceFactory
+import at.aau.hexabrawl.websocketserver.service.DisconnectCleanupService
 
 /**
  * Tests fuer den DisconnectCleanupService.

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/DisconnectHandlerTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import at.aau.hexabrawl.websocketserver.TestServiceFactory
+import at.aau.hexabrawl.websocketserver.service.GameService
 
 class DisconnectHandlerTest {
 

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConnectivityTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConnectivityTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import at.aau.hexabrawl.websocketserver.TestServiceFactory
+import at.aau.hexabrawl.websocketserver.service.GameService
 
 class FieldConnectivityTest {
 

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConquestTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConquestTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import at.aau.hexabrawl.websocketserver.TestServiceFactory
+import at.aau.hexabrawl.websocketserver.service.GameService
 
 
 class FieldConquestTest {

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import at.aau.hexabrawl.websocketserver.TestServiceFactory
+import at.aau.hexabrawl.websocketserver.service.GameService
 
 
 class FieldTest {

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/RoomCleanupServiceTest.kt
@@ -1,5 +1,6 @@
 package at.aau.hexabrawl.websocketserver.model
 
+import at.aau.hexabrawl.websocketserver.service.RoomCleanupService
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/UnitTypeTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/UnitTypeTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.BeforeEach
 import at.aau.hexabrawl.websocketserver.TestServiceFactory
+import at.aau.hexabrawl.websocketserver.service.GameService
 
 
 class UnitTypeTest {

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/CombatServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/CombatServiceTest.kt
@@ -1,5 +1,6 @@
 package at.aau.hexabrawl.websocketserver.model
 
+import at.aau.hexabrawl.websocketserver.service.CombatService
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/websocket/GameServiceTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import at.aau.hexabrawl.websocketserver.TestServiceFactory
+import at.aau.hexabrawl.websocketserver.service.GameService
 
 class GameServiceTest {
 


### PR DESCRIPTION
**Problem / Kontext**
Dieser PR ist der zweite Schritt (Sub-Issue #209) des `GameService` Refactorings (Parent #207). Die komplette Wirtschafts-Logik (Einkommen, Upkeep, Einheitenkauf und der Rundenabschluss) wird aus der God-Class in einen dedizierten `EconomyService` ausgelagert. Dieser PR baut auf der in #208 eingeführten `TestServiceFactory` auf.

**Lösung / Umsetzung**
* **`EconomyService`:** Neue `@Service`-Bean erstellt. Beinhaltet nun `computeIncome`, `computeUpkeep`, `applyEconomy`, `buyUnit` und `recomputePlayerStats` sowie die zugehörigen Wirtschafts-Konstanten.
* **`GameService` Bridges:** 
  * Die Konstanten (`STARTING_GOLD`, `FARM_BASE_COST`, `UNIT_PRICE` etc.) wurden als Bridge-Aliase im `GameService` belassen, damit externe Controller-Aufrufe nicht brechen.
  * `recomputePlayerStats` und `buyUnit` delegieren nun als Einzeiler an den neuen Service.
  * In `switchTurn` wird der Economy-Tick nun über `economyService.applyEconomy(state, it)` abgewickelt.
* **Test-Infrastruktur:** `TestServiceFactory` wurde um den neuen Constructor-Parameter erweitert, wodurch alle Tests kompatibel bleiben.

**Testing**
* Lokaler Maven-Build läuft fehlerfrei durch.
* Alle Unit-Tests (inklusive Controller-Tests, die auf die Konstanten zugreifen) sind grün.

Closes #209