### PR TITLE
Refactor #210: CheatGiftService extrahieren

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/CheatGiftService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/CheatGiftService.kt
@@ -1,0 +1,66 @@
+package at.aau.hexabrawl.websocketserver.service
+
+import at.aau.hexabrawl.websocketserver.model.GameState
+import at.aau.hexabrawl.websocketserver.model.PendingGift
+import org.springframework.stereotype.Service
+
+/**
+ * Schummel-Geschenk-Logik (Cheat-Gift-Feature).
+ *
+ * Spielmechanik:
+ *  - Ein Spieler oeffnet ein Geschenk und bekommt sofort delta Gold gebucht
+ *    (kann auch negativ sein, mit Cap bei 0).
+ *  - Alle anderen Spieler bekommen die Chance zu stehlen — Owner-Gold zurueck,
+ *    Stealer-Gold +delta. Erster Stealer gewinnt.
+ *  - hasUsedGift verhindert mehrfaches Oeffnen pro Spieler.
+ *
+ * Validierungen liegen im Controller — diese Service-Methoden mutieren nur.
+ */
+@Service
+class CheatGiftService {
+
+    fun claimCheatGift(
+        state: GameState,
+        playerName: String,
+        delta: Int
+    ): GameState = synchronized(state.lock) {
+        val player = state.players.find { it.name == playerName } ?: return state
+
+        player.gold += delta
+        if (player.gold < 0) player.gold = 0
+        player.hasUsedGift = true
+
+        state.pendingGift = PendingGift(
+            ownerName = player.name,
+            delta = delta,
+            pendingDecisions = state.players.size - 1
+        )
+        return state
+    }
+
+    fun respondCheatSteal(
+        state: GameState,
+        playerName: String,
+        accept: Boolean
+    ): GameState = synchronized(state.lock) {
+        val gift = state.pendingGift ?: return state
+        val player = state.players.find { it.name == playerName } ?: return state
+
+        if (accept) {
+            val owner = state.players.first { it.name == gift.ownerName }
+            owner.gold -= gift.delta
+            if (owner.gold < 0) owner.gold = 0
+            player.gold += gift.delta
+            if (player.gold < 0) player.gold = 0
+            state.pendingGift = null
+        } else {
+            val remaining = gift.pendingDecisions - 1
+            state.pendingGift = if (remaining > 0) {
+                gift.copy(pendingDecisions = remaining)
+            } else {
+                null
+            }
+        }
+        return state
+    }
+}

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/EconomyService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/EconomyService.kt
@@ -1,5 +1,9 @@
-package at.aau.hexabrawl.websocketserver.model
+package at.aau.hexabrawl.websocketserver.service
 
+import at.aau.hexabrawl.websocketserver.model.GameState
+import at.aau.hexabrawl.websocketserver.model.GameUnit
+import at.aau.hexabrawl.websocketserver.model.Player
+import at.aau.hexabrawl.websocketserver.model.UnitType
 import org.springframework.stereotype.Service
 
 /**

--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/GameService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/GameService.kt
@@ -1,6 +1,5 @@
 package at.aau.hexabrawl.websocketserver.service
 
-import at.aau.hexabrawl.websocketserver.model.EconomyService
 import at.aau.hexabrawl.websocketserver.model.Field
 import at.aau.hexabrawl.websocketserver.model.GameMode
 import at.aau.hexabrawl.websocketserver.model.GameState
@@ -16,7 +15,7 @@ import org.springframework.stereotype.Service
 
 @Service
 class GameService(
-    private val combatService: CombatService, private val connectivityService: ConnectivityService, private val economyService: EconomyService
+    private val combatService: CombatService, private val connectivityService: ConnectivityService, private val economyService: EconomyService, private val cheatGiftService: CheatGiftService
 ) {
 
     val gameState = GameState()
@@ -559,85 +558,11 @@ class GameService(
     /** Bridge zu EconomyService — Controller + Tests rufen das auf. */
     fun recomputePlayerStats(state: GameState) = economyService.recomputePlayerStats(state)
 
-    /**
-     * Schummel-Geschenk oeffnen (Cheat-Gift).
-     *
-     * Diese Methode setzt voraus, dass der Controller bereits alle
-     * Validierungen durchgefuehrt hat (Status IN_PROGRESS, delta in
-     * -10..10, pendingGift == null, Spieler existiert, hasUsedGift
-     * == false).
-     *
-     * Verhalten:
-     *  - delta wird auf player.gold gebucht. Bei Resultat < 0 wird
-     *    auf 0 gecappt (User-Entscheidung: kein negatives Gold).
-     *  - player.hasUsedGift wird auf true gesetzt (sticky bis Spielende).
-     *  - state.pendingGift wird mit pendingDecisions = players.size - 1
-     *    angelegt, sodass alle anderen Spieler die Steal-Entscheidung
-     *    treffen koennen.
-     *
-     * Thread-safe ueber state.lock.
-     */
-    fun claimCheatGift(
-        state: GameState,
-        playerName: String,
-        delta: Int
-    ): GameState = synchronized(state.lock) {
-        val player = state.players.find { it.name == playerName } ?: return state
+    /** Bridge zu CheatGiftService.claimCheatGift. */
+    fun claimCheatGift(state: GameState, playerName: String, delta: Int): GameState = cheatGiftService.claimCheatGift(state, playerName, delta)
 
-        player.gold += delta
-        if (player.gold < 0) player.gold = 0
-        player.hasUsedGift = true
-
-        state.pendingGift = PendingGift(
-            ownerName = player.name,
-            delta = delta,
-            pendingDecisions = state.players.size - 1
-        )
-        return state
-    }
-
-    /**
-     * Antwort auf das Schummel-Geschenk (Steal-Versuch).
-     *
-     * Diese Methode setzt voraus, dass der Controller bereits validiert
-     * hat (pendingGift != null, playerName != ownerName, Spieler existiert).
-     *
-     * Bei accept=true (atomarer Steal-Switch):
-     *  - owner.gold -= delta, bei Resultat < 0 wird auf 0 gecappt
-     *  - stealer.gold += delta, bei Resultat < 0 wird auf 0 gecappt
-     *  - pendingGift = null
-     *
-     * Bei accept=false:
-     *  - pendingDecisions -= 1
-     *  - bei 0 → pendingGift = null (keiner wollte stehlen)
-     *
-     * Thread-safe ueber state.lock.
-     */
-    fun respondCheatSteal(
-        state: GameState,
-        playerName: String,
-        accept: Boolean
-    ): GameState = synchronized(state.lock) {
-        val gift = state.pendingGift ?: return state
-        val player = state.players.find { it.name == playerName } ?: return state
-
-        if (accept) {
-            val owner = state.players.first { it.name == gift.ownerName }
-            owner.gold -= gift.delta
-            if (owner.gold < 0) owner.gold = 0
-            player.gold += gift.delta
-            if (player.gold < 0) player.gold = 0
-            state.pendingGift = null
-        } else {
-            val remaining = gift.pendingDecisions - 1
-            state.pendingGift = if (remaining > 0) {
-                gift.copy(pendingDecisions = remaining)
-            } else {
-                null
-            }
-        }
-        return state
-    }
+    /** Bridge zu CheatGiftService.respondCheatSteal. */
+    fun respondCheatSteal(state: GameState, playerName: String, accept: Boolean): GameState = cheatGiftService.respondCheatSteal(state, playerName, accept)
 
     /**
      * Entfernt einen Spieler restlos aus dem Spiel (bei Disconnect oder Basis-Verlust).

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/TestServiceFactory.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/TestServiceFactory.kt
@@ -1,6 +1,7 @@
 package at.aau.hexabrawl.websocketserver
 
-import at.aau.hexabrawl.websocketserver.model.EconomyService
+import at.aau.hexabrawl.websocketserver.service.CheatGiftService
+import at.aau.hexabrawl.websocketserver.service.EconomyService
 import at.aau.hexabrawl.websocketserver.service.CombatService
 import at.aau.hexabrawl.websocketserver.service.GameService
 import at.aau.hexabrawl.websocketserver.service.ConnectivityService
@@ -19,7 +20,8 @@ object TestServiceFactory {
         val combatService = CombatService()
         val connectivityService = ConnectivityService()
         val economyService = EconomyService()
-        return GameService(combatService, connectivityService, economyService)
+        val cheatGiftService = CheatGiftService()
+        return GameService(combatService, connectivityService, economyService, cheatGiftService)
 
     }
 }


### PR DESCRIPTION
**Problem / Kontext**
Dieser PR ist der dritte Schritt (Sub-Issue #210) des `GameService` Refactorings (Parent #207). Die Logik für das Cheat-Geschenk-Feature (`claimCheatGift` und `respondCheatSteal`) war komplett isoliert und wurde nun in einen eigenen Service ausgelagert.

**Lösung / Umsetzung**
* **`CheatGiftService`:** Neue `@Service`-Bean im `model`-Package (analog zu den vorherigen PRs zur Vermeidung von Import-Konflikten während des Refactorings) erstellt.
* **`GameService` Bridges:** Die beiden betroffenen Methoden wurden durch einfache Einzeiler ersetzt, die direkt an den neuen Service delegieren. Die Controller bleiben dadurch unberührt.
* **Test-Infrastruktur:** Die `TestServiceFactory` wurde um den neuen Service ergänzt, wodurch alle 354 Unit-Tests weiterhin erfolgreich durchlaufen.

**Testing**
* Lokaler Maven-Build läuft fehlerfrei.
* Unit- und Integration-Tests sind grün.

Closes #210