### PR TITLE
fix(connectivity): un-skeleton fields when path to base is restored

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/ConnectivityService.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/service/ConnectivityService.kt
@@ -38,8 +38,11 @@ class ConnectivityService {
 
             val connected = bfsConnectedFields(state, player.name, baseUnit.x, baseUnit.y)
 
-            state.fields.filter { it.owner == player.name && !it.isSkeleton }.forEach { field ->
-                if ((field.x to field.y) !in connected) {
+            state.fields.filter { it.owner == player.name }.forEach { field ->
+                val coord = field.x to field.y
+                if (coord in connected) {
+                    field.isSkeleton = false
+                } else if (!field.isSkeleton) {
                     field.isSkeleton = true
                     state.units.filter {
                         it.x == field.x && it.y == field.y &&
@@ -68,7 +71,6 @@ class ConnectivityService {
                 if ((nx to ny) in visited) continue
                 val field = state.fields.firstOrNull { it.x == nx && it.y == ny } ?: continue
                 if (field.owner != playerName) continue
-                if (field.isSkeleton) continue
                 visited.add(nx to ny)
                 queue.add(nx to ny)
             }

--- a/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConnectivityTest.kt
+++ b/src/test/kotlin/at/aau/hexabrawl/websocketserver/model/FieldConnectivityTest.kt
@@ -85,15 +85,48 @@ class FieldConnectivityTest {
     }
 
     @Test
-    fun `skeleton corridor blocks bfs path`() {
+    fun `skeleton field connected to base gets un-skeletonized`() {
         val state = stateWithBase("Alice", 0, 0).apply {
-            // (1,0) ist Alice aber bereits SKELETON – sollte als Pfad nicht zählen
             fields.add(Field(1, 0, owner = "Alice", isSkeleton = true))
-            fields.add(Field(2, 0, owner = "Alice"))
+            fields.add(Field(2, 0, owner = "Alice", isSkeleton = true))
         }
         connectivityService.recomputeConnectivity(state)
-        val field20 = state.fields.first { it.x == 2 && it.y == 0 }
-        assertTrue(field20.isSkeleton)
+        assertFalse(state.fields.first { it.x == 1 && it.y == 0 }.isSkeleton)
+        assertFalse(state.fields.first { it.x == 2 && it.y == 0 }.isSkeleton)
+    }
+
+    @Test
+    fun `genuinely disconnected skeleton field stays skeleton`() {
+        val state = stateWithBase("Alice", 0, 0).apply {
+            // (3,0) hat keinen Pfad zur BASE – (1,0) und (2,0) fehlen
+            fields.add(Field(3, 0, owner = "Alice", isSkeleton = true))
+        }
+        connectivityService.recomputeConnectivity(state)
+        assertTrue(state.fields.first { it.x == 3 && it.y == 0 }.isSkeleton)
+    }
+
+    @Test
+    fun `skeleton fields reconnected after blocking path restored`() {
+        val state = stateWithBase("Alice", 0, 0).apply {
+            fields.add(Field(1, 0, owner = "Alice"))
+            fields.add(Field(2, 0, owner = "Alice", isSkeleton = true))
+            fields.add(Field(3, 0, owner = "Alice", isSkeleton = true))
+        }
+        connectivityService.recomputeConnectivity(state)
+        assertFalse(state.fields.first { it.x == 2 && it.y == 0 }.isSkeleton)
+        assertFalse(state.fields.first { it.x == 3 && it.y == 0 }.isSkeleton)
+    }
+
+    @Test
+    fun `skeleton units on reconnected field stay skeleton`() {
+        val state = stateWithBase("Alice", 0, 0).apply {
+            fields.add(Field(1, 0, owner = "Alice"))
+            fields.add(Field(2, 0, owner = "Alice", isSkeleton = true))
+            units.add(GameUnit(player = "Alice", x = 2, y = 0, type = UnitType.SKELETON))
+        }
+        connectivityService.recomputeConnectivity(state)
+        assertFalse(state.fields.first { it.x == 2 && it.y == 0 }.isSkeleton)
+        assertEquals(UnitType.SKELETON, state.units.first { it.x == 2 && it.y == 0 }.type)
     }
 
     @Test


### PR DESCRIPTION
Previously skeleton fields were excluded from BFS traversal and the outer loop, making the skeleton state permanent even after a blocking enemy territory was reclaimed. Now BFS traverses all owned fields and connected skeleton fields are cleared — skeleton units on those fields stay skeleton (no auto-revival).