### PR TITLE
fix(stomp): assign Principal so /user/queue/errors-Frames reach the App

### DIFF
--- a/src/main/kotlin/at/aau/hexabrawl/websocketserver/config/WebSocketAuthConfig.kt
+++ b/src/main/kotlin/at/aau/hexabrawl/websocketserver/config/WebSocketAuthConfig.kt
@@ -1,0 +1,53 @@
+package at.aau.hexabrawl.websocketserver.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.Message
+import org.springframework.messaging.MessageChannel
+import org.springframework.messaging.simp.config.ChannelRegistration
+import org.springframework.messaging.simp.stomp.StompCommand
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.messaging.support.ChannelInterceptor
+import org.springframework.messaging.support.MessageHeaderAccessor
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+import java.security.Principal
+
+/**
+ * Setzt jeder neuen STOMP-Session einen anonymen Principal mit der
+ * WebSocket-Session-ID als Namen.
+ *
+ * Hintergrund: `SimpMessagingTemplate.convertAndSendToUser(name, ...)`
+ * routet ueber `SimpUserRegistry`. Der Registry indexiert Sessions
+ * ausschliesslich nach Principal-Name — Sessions ohne Principal
+ * werden gar nicht getrackt. Ohne Authentication ist das bei uns
+ * der Default, weshalb bisher alle Error-Frames an
+ * `/user/queue/errors` stumm verworfen wurden.
+ *
+ * Loesung: beim CONNECT-Frame setzen wir [StompHeaderAccessor.user]
+ * auf einen [Principal], dessen Name exakt die WebSocket-Session-ID
+ * ist. Damit ist die Session unter genau dieser ID im Registry
+ * eingetragen und `convertAndSendToUser(sessionId, ...)` findet sie.
+ *
+ * Es muss nichts an den Controllern geaendert werden — sie nutzen
+ * weiterhin [SimpMessageHeaderAccessor.sessionId] als Identifier
+ * und das stimmt jetzt mit dem Principal-Namen ueberein.
+ */
+@Configuration
+class WebSocketAuthConfig : WebSocketMessageBrokerConfigurer {
+
+    override fun configureClientInboundChannel(registration: ChannelRegistration) {
+        registration.interceptors(object : ChannelInterceptor {
+            override fun preSend(message: Message<*>, channel: MessageChannel): Message<*> {
+                val accessor = MessageHeaderAccessor.getAccessor(
+                    message,
+                    StompHeaderAccessor::class.java
+                )
+                if (accessor?.command == StompCommand.CONNECT) {
+                    accessor.sessionId?.let { sid ->
+                        accessor.user = Principal { sid }
+                    }
+                }
+                return message
+            }
+        })
+    }
+}


### PR DESCRIPTION
Bisher hat keine STOMP-Session einen Principal — ohne Authentication ist getPrincipal() default null. Folge: der SimpUserRegistry trackt die Sessions nicht, und convertAndSendToUser(sessionId, /queue/errors, ...) verwirft alle Frames, weil Spring keinen User mit diesem Namen findet. Dadurch hat die App NIE einen Server-seitigen Error gesehen (NAME_ALREADY_TAKEN, NOT_YOUR_TURN, INVALID_MOVE, ...).

Fix: ChannelInterceptor auf clientInboundChannel registriert. Beim CONNECT-Frame setzt er accessor.user auf einen Principal mit name == WebSocket-Session-ID. Damit ist die Session im UserRegistry unter exakt der ID eingetragen, die die Controller bereits als sessionId nutzen — convertAndSendToUser routet jetzt korrekt.

Keine Anpassung an Controllern, Tests oder App noetig.